### PR TITLE
Resolve mirrored external automation runs by job id

### DIFF
--- a/clawbits/db/table_write.py
+++ b/clawbits/db/table_write.py
@@ -1935,26 +1935,41 @@ class TableWrite:
     ) -> int:
         """Upsert reported run-log entries, de-duped on
         ``(automation_id, gateway_run_id)``. Runs for an automation that does
-        not belong to ``agent_id`` are ignored. Returns the number upserted."""
+        not belong to ``agent_id`` are ignored. Returns the number upserted.
+
+        Managed jobs report the real ``automation_id`` back to Clawbits, but
+        mirrored external jobs only have a stable gateway job id. The plugin may
+        therefore send a synthetic ``automation_id`` for an external job and the
+        real ``gateway_job_id`` beside it; when the direct id lookup misses, fall
+        back to resolving the owner row by ``(agent_id, gateway_job_id)``.
+        """
         runs = (runs or [])[:max_runs]
         count = 0
         for item in runs:
             automation_id = item.get("automation_id")
-            if not automation_id:
-                continue
-            owner = session.get(Automation, automation_id)
+            owner = session.get(Automation, automation_id) if automation_id else None
+            if owner is None or owner.agent_id != agent_id:
+                gateway_job_id = item.get("gateway_job_id")
+                if not isinstance(gateway_job_id, str) or not gateway_job_id:
+                    continue
+                owner = session.exec(
+                    select(Automation)
+                    .where(Automation.agent_id == agent_id)
+                    .where(Automation.gateway_job_id == gateway_job_id)
+                ).first()
             if owner is None or owner.agent_id != agent_id:
                 continue
+            resolved_automation_id = owner.automation_id
             run_id = item.get("gateway_run_id")
             existing = None
             if run_id:
                 existing = session.exec(
                     select(AutomationRun)
-                    .where(AutomationRun.automation_id == automation_id)
+                    .where(AutomationRun.automation_id == resolved_automation_id)
                     .where(AutomationRun.gateway_run_id == run_id)
                 ).first()
             target = existing or AutomationRun(
-                automation_id=automation_id,
+                automation_id=resolved_automation_id,
                 agent_id=agent_id,
                 gateway_run_id=run_id,
             )

--- a/tests/fastapi/test_automations.py
+++ b/tests/fastapi/test_automations.py
@@ -221,6 +221,57 @@ def test_run_now_flow(test_client: TestClient, _test_engine):
     assert r.status_code == 404, r.text
 
 
+def test_external_automation_runs_resolve_by_gateway_job_id(
+    test_client: TestClient, _test_engine
+):
+    """External mirrored jobs can ingest runs even when the plugin reports a
+    synthetic automation id, as long as the gateway job id matches."""
+    agent_id, api_key, token, org_id = _setup(test_client, "ext-runs@clawbits.ai")
+    base = f"/api/human/orgs/{org_id}/agents/{agent_id}/automations"
+    agent_h = {"Authorization": f"Bearer {api_key}"}
+
+    mirror = {
+        "external": [
+            {
+                "gateway_job_id": "cron_external",
+                "name": "External nightly",
+                "reported_spec": {"name": "External nightly"},
+                "reported_state": {"lastRunStatus": "ok", "lastRunAtMs": 2000},
+            }
+        ],
+        "runs": [
+            {
+                "automation_id": "external:cron_external",
+                "gateway_job_id": "cron_external",
+                "gateway_run_id": "run:2000",
+                "status": "ok",
+                "started_at_ms": 2000,
+                "finished_at_ms": 2125,
+                "summary": {"mirrored_external": True, "delivered": True},
+            }
+        ],
+    }
+    r = test_client.post(
+        "/api/agentic/automations/state", headers=agent_h, json=mirror
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["runs_ingested"] == 1
+
+    listed = test_client.get(base, headers=auth_headers(token)).json()["automations"]
+    assert len(listed) == 1
+    external = listed[0]
+    assert external["managed_by"] == "external"
+    assert external["gateway_job_id"] == "cron_external"
+
+    runs = test_client.get(
+        f"{base}/{external['automation_id']}/runs", headers=auth_headers(token)
+    ).json()
+    assert len(runs["runs"]) == 1
+    assert runs["runs"][0]["gateway_run_id"] == "run:2000"
+    assert runs["runs"][0]["summary"]["mirrored_external"] is True
+
+
+
 def test_delivery_target_channel(test_client: TestClient, _test_engine):
     """Operator can target a channel the agent is in; a non-member channel is
     rejected; webhook delivery is neutralized to announce."""


### PR DESCRIPTION
## Summary
- resolve mirrored external automation runs by gateway job id when the plugin reports a synthetic automation id
- keep managed automation run ingestion unchanged while allowing external job mirrors to attach to the correct automation row
- add a FastAPI regression test covering external run ingestion via the state-report endpoint

## Testing
- python3 -m py_compile clawbits/db/table_write.py tests/fastapi/test_automations.py

## Notes
- Full pytest was not runnable in this checkout because the local Python test toolchain was not installed.
