### PR TITLE
Fix mobile landing, update demo

### DIFF
--- a/web/src/components/AppDemo.astro
+++ b/web/src/components/AppDemo.astro
@@ -28,7 +28,8 @@ import {
   UserMultiple02Icon,
 } from "@hugeicons/core-free-icons";
 import { ico } from "../lib/appicon";
-import { CHATS, type Msg, type Species } from "../content/demo-chats";
+import { CHATS, type Chat, type Msg, type Species } from "../content/demo-chats";
+import { LINKS } from "../config";
 
 /**
  * The hero's product frame: a faithful, sample-data recreation of the real
@@ -68,6 +69,23 @@ import { CHATS, type Msg, type Species } from "../content/demo-chats";
 /* The conversation set is SHARED with PhoneDemo.astro - see the module's
  * own note for why it is not defined here any more. */
 
+
+/** Which agents are agents, for the avatar shape and the reply author. */
+const AGENTS = new Set(["atlas", "hermes", "scout", "quill", "forge"]);
+
+/**
+ * Who answers when a visitor sends a message from the demo composer.
+ *
+ * A DM is answered by its counterpart; a channel by the last agent that spoke
+ * in it, which is the one the reader just watched being useful. Resolved here
+ * rather than in the script so the markup carries it per conversation and the
+ * script stays a dumb DOM builder.
+ */
+const replyFrom = (c: Chat) => {
+  if (c.species !== "channel") return { name: c.name, ava: c.src };
+  const last = [...c.msgs].reverse().find((m) => !m.own && m.name && AGENTS.has(m.name));
+  return last ? { name: last.name!, ava: last.ava! } : { name: c.name, ava: c.src };
+};
 
 /** Same-author run detection for grouping (name inside the bubble only on
  * group start, avatar only on group end - MessageRow.tsx). */
@@ -176,7 +194,7 @@ const CARDS: Card[] = [
 ];
 ---
 
-<div class="win" role="group" aria-label="Clawbits app demo">
+<div class="win" role="group" aria-label="Clawbits app demo" data-signup={LINKS.signup}>
   <input type="radio" name="demo-view" id="v-home" class="vr" aria-label="Show the Home view" />
   <input type="radio" name="demo-view" id="v-agents" class="vr" aria-label="Show the Agents view" />
   {CHATS.map((c) => (
@@ -645,7 +663,13 @@ const CARDS: Card[] = [
         {/* One view per conversation. */}
         {
           CHATS.map((c) => (
-            <section class:list={["view", "cv", `view-${c.id}`]} aria-label={`${c.name} conversation`}>
+            <section
+              class:list={["view", "cv", `view-${c.id}`]}
+              aria-label={`${c.name} conversation`}
+              data-reply-name={replyFrom(c).name}
+              data-reply-ava={replyFrom(c).ava}
+              data-channel={c.species === "channel" ? "" : undefined}
+            >
               <header class="pane-head chat-head">
                 <img
                   class:list={["ava", "s22", { "ava-h": c.species === "human", "ava-a": c.species === "agent", "ava-c": c.species === "channel" }]}
@@ -859,20 +883,138 @@ const CARDS: Card[] = [
 </div>
 
 <script>
-  // Seed every conversation ~120px above its latest message, so each one opens
-  // on its most recent exchange rather than its oldest. Hidden views keep
-  // layout (visibility, not display), so their offsets can be set up front.
+  // Seed every conversation just short of its end, so each one opens on its
+  // most recent exchange. The offset was 120px, from when a wheel-down was
+  // meant to run the chat to its bottom before chaining to the page - the
+  // hand-off below does that job now, so this only decides where the reader
+  // lands. Hidden views keep layout (visibility, not display), so their
+  // offsets can be set up front.
+  const SEED_ABOVE_END = 40;
+
   for (const feed of document.querySelectorAll<HTMLElement>(".feed")) {
     const max = feed.scrollHeight - feed.clientHeight;
-    if (max > 0) feed.scrollTop = Math.max(0, max - 120);
+    if (max > 0) feed.scrollTop = Math.max(0, max - SEED_ABOVE_END);
   }
 
-  // The composer is a single-line field. `white-space: nowrap` handles wrapping
-  // but not explicit breaks, so Enter is refused outright and a paste is
-  // flattened to one line before it lands.
+  // ── Sending ──────────────────────────────────────────────────────────────
+  //
+  // The composer is a single-line field, so Enter has nothing to insert and is
+  // free to mean "send". Whatever is typed becomes a real outgoing bubble, and
+  // the conversation's own agent answers - the one the reader has just watched
+  // being useful in that thread.
+  //
+  // The reply is the honest one. This demo is sample data and cannot answer
+  // anything; saying so and offering the real thing beats a canned response
+  // that pretends otherwise.
+  // Shared with the scroll hand-off further down.
+  const win = document.querySelector<HTMLElement>(".win");
+  const signup = win?.dataset.signup ?? "/";
+
+  // Astro scopes this component's CSS behind a `data-astro-cid-*` attribute it
+  // stamps on every element it renders. An element built with createElement
+  // has no such attribute, so NONE of the rules below reach it - a sent
+  // message came out as unstyled text with a full-size avatar. Every node this
+  // script creates is stamped with the same attribute the server used.
+  const scopeAttr = [...(document.querySelector(".msg")?.attributes ?? [])]
+    .map((a) => a.name)
+    .find((n) => n.startsWith("data-astro-cid-"));
+
+  /** createElement + the component's style scope. */
+  const el = <K extends keyof HTMLElementTagNameMap>(tag: K, className: string) => {
+    const node = document.createElement(tag);
+    node.className = className;
+    if (scopeAttr) node.setAttribute(scopeAttr, "");
+    return node;
+  };
+
+  /** Same shape as a rendered .msg - see the message markup above. */
+  const appendMessage = (
+    feed: HTMLElement,
+    opts: { own?: boolean; name?: string; ava?: string; body: (string | Node)[][] },
+  ) => {
+    const msg = el("div", opts.own ? "msg own arrive" : "msg arrive");
+
+    if (opts.ava) {
+      const gutter = el("span", "m-gutter");
+      const img = el("img", "ava ava-a s28");
+      img.src = opts.ava;
+      img.alt = "";
+      img.width = 128;
+      img.height = 128;
+      gutter.append(img);
+      msg.append(gutter);
+    }
+
+    const bubble = el("div", "bubble");
+
+    if (opts.name) {
+      const who = el("b", "b-name");
+      who.textContent = opts.name;
+      bubble.append(who);
+    }
+
+    // One <p> per paragraph - the bubble already spaces them (p + p below),
+    // the same way the sample data's two-paragraph release note is rendered.
+    for (const para of opts.body) {
+      const p = el("p", "");
+      p.append(...para);
+      bubble.append(p);
+    }
+
+    const meta = el("span", "m-meta");
+    meta.textContent = new Date().toLocaleTimeString([], {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    bubble.append(meta);
+
+    const col = el("div", "m-col");
+    col.append(bubble);
+    msg.append(col);
+
+    feed.append(msg);
+    feed.scrollTop = feed.scrollHeight;
+  };
+
+  const send = (field: HTMLElement) => {
+    const text = (field.textContent ?? "").trim();
+    if (!text) return;
+
+    const view = field.closest<HTMLElement>(".view");
+    const feed = view?.querySelector<HTMLElement>(".feed");
+    if (!view || !feed) return;
+
+    field.textContent = "";
+    appendMessage(feed, { own: true, body: [[text]] });
+
+    // A beat, so the reply reads as an answer rather than as part of the send.
+    window.setTimeout(() => {
+      const isChannel = view.hasAttribute("data-channel");
+      const link = el("a", "lnk");
+      link.href = signup;
+      // Bold, so the call to action reads as the one thing to do here rather
+      // than as another link in a sentence.
+      const label = el("b", "");
+      label.textContent = "Get started";
+      link.append(label);
+
+      appendMessage(feed, {
+        name: isChannel ? view.dataset.replyName : undefined,
+        ava: isChannel ? view.dataset.replyAva : undefined,
+        body: [
+          ["That's the kind of thing your own agent would pick up."],
+          ["This one is only a preview - ", link],
+        ],
+      });
+    }, 650);
+  };
+
   for (const field of document.querySelectorAll<HTMLElement>(".comp-text")) {
     field.addEventListener("keydown", (event) => {
-      if (event.key === "Enter") event.preventDefault();
+      if (event.key !== "Enter") return;
+      // Nothing to insert on one line, so Enter sends instead.
+      event.preventDefault();
+      send(field);
     });
 
     field.addEventListener("paste", (event) => {
@@ -884,6 +1026,11 @@ const CARDS: Card[] = [
       // the field's native undo stack intact.
       if (flat) document.execCommand("insertText", false, flat);
     });
+
+    const button = field.closest(".composer")?.querySelector(".send");
+    button?.addEventListener("click", () => {
+      send(field);
+    });
   }
 
   // SCROLL HAND-OFF. Chrome latches a wheel gesture to whichever scroller it
@@ -894,8 +1041,6 @@ const CARDS: Card[] = [
   //
   // Delegated from .win so it costs one listener rather than one per pane,
   // and only fires for wheels that actually landed inside the window.
-  const win = document.querySelector<HTMLElement>(".win");
-
   win?.addEventListener(
     "wheel",
     (event) => {
@@ -1324,7 +1469,9 @@ const CARDS: Card[] = [
     flex: 1;
     min-width: 0;
     display: flex;
-    margin: 0 8px 0 0;
+    /* Bottom matches the right - the content card floats off both edges of
+     * the window rather than running into the bottom one. */
+    margin: 0 8px 8px 0;
     border-radius: 14px;
     border: 1px solid var(--line);
     background: rgb(242 239 232 / 0.82);
@@ -2174,6 +2321,24 @@ const CARDS: Card[] = [
     }
   }
 
+  /* Sent and received messages arrive rather than appear - the same rise the
+   * page's other card visuals use for a new bubble. Applied by the script to
+   * anything it appends; the server-rendered thread is already in place on
+   * load and must not replay it. */
+  @media (prefers-reduced-motion: no-preference) {
+    .msg.arrive {
+      animation: demo-msg-in 340ms var(--ease-out-expo) backwards;
+    }
+  }
+
+  @keyframes demo-msg-in {
+    from {
+      opacity: 0;
+      translate: 0 10px;
+      scale: 0.97;
+    }
+  }
+
   @keyframes demo-pulse {
     50% { opacity: 0.5; }
   }
@@ -2222,7 +2387,11 @@ const CARDS: Card[] = [
     width: 100%;
     max-width: 832px;
     margin-inline: auto;
-    padding: 0 8px 100px;
+    /* The bottom padding is the composer's clearance: the composer floats over
+     * this feed, so at the very end of a thread this is all that keeps the last
+     * bubble off it. Sized to the composer (~86px to its top edge) plus a
+     * breath, not to a round number. */
+    padding: 0 8px 106px;
     display: flex;
     flex-direction: column;
     overflow-y: auto;
@@ -2669,6 +2838,8 @@ const CARDS: Card[] = [
   /* Send: 32px, radius 10; ink primary when there's a draft, the app's
    * disabled muted state when the composer is empty. */
   .send {
+    pointer-events: auto;
+    cursor: pointer;
     width: 32px;
     height: 32px;
     border-radius: 10px;
@@ -2676,6 +2847,19 @@ const CARDS: Card[] = [
     place-items: center;
     background: var(--primary);
     color: var(--primary-fg);
+    /* Same press language as the platform cards and agent tiles on this page:
+     * a small scale, quick in and slower out. */
+    transition: scale 120ms var(--ease-out-expo);
+  }
+
+  .send:active {
+    scale: 0.9;
+    transition-duration: 40ms;
+  }
+
+  /* A dead button should not pretend to be pressable. */
+  .send.off {
+    pointer-events: none;
   }
 
   .send.off {

--- a/web/src/components/PhoneDemo.astro
+++ b/web/src/components/PhoneDemo.astro
@@ -1419,11 +1419,28 @@ const rowPreview = (c: Chat) => c.preview;
    * get the resting layout, not an animation with no timeline to sit on. */
   @supports (animation-timeline: scroll()) {
     @media (prefers-reduced-motion: no-preference) {
+      /* LONGHANDS ONLY, and never the `animation` shorthand.
+       *
+       * `animation: linear both` has no name, so a minifier is free to fold it
+       * to `animation: none` - and because the shorthand also RESETS
+       * animation-timeline, Lightning CSS took the timeline declaration with
+       * it. Staging shipped `animation:none;animation-range:0 210px` and no
+       * timeline at all, which is why the feed sat at its resting position on
+       * the device while working perfectly in `astro dev` (which does not
+       * minify). Verify this rule against `bun run build` output, not dev.
+       *
+       * `animation-duration: auto` is also load-bearing: it is what maps an
+       * animation across a scroll range. The shorthand's omitted duration
+       * resolves to 0s in some engines, which finishes the animation instantly
+       * at the start of the range - the same wrong-looking result, arrived at
+       * a different way. */
       .cstack,
       .lcard {
-        animation: linear both;
+        animation-duration: auto;
+        animation-timing-function: linear;
+        animation-fill-mode: both;
         animation-timeline: scroll(root block);
-        animation-range: 0 210px;
+        animation-range: 0px 210px;
       }
 
       .cstack {
@@ -1434,6 +1451,15 @@ const rowPreview = (c: Chat) => c.preview;
         animation-name: ph-list;
       }
     }
+  }
+
+  /* The opening frame, as a plain static value. Without this a browser that
+   * cannot run scroll-driven animations - or a build that loses the timeline,
+   * as staging did - falls back to translate 0, which is the END of the
+   * thread. Now the fallback is the composition we actually designed; it just
+   * does not move. */
+  .cstack {
+    translate: 0 calc(232 * var(--pu));
   }
 
   /* Bottom-anchored, so pushing the stack DOWN reveals earlier messages. */

--- a/web/src/components/ShaderBackdrop.tsx
+++ b/web/src/components/ShaderBackdrop.tsx
@@ -16,7 +16,8 @@ import { GrainGradient } from "@paper-design/shaders-react";
 
 export const CANDY_COLORS = ["#e8425c", "#8f5bd6", "#4a8fe0", "#f09a3f", "#b03927"];
 
-/** Matches --color-canvas in global.css. */
+/** Matches --color-canvas in global.css. Keep the two in step: this is the
+ *  shader's own ground, so a drift shows as a seam where the canvas ends. */
 const CANVAS_INK = "#141311";
 
 interface Props {
@@ -25,6 +26,16 @@ interface Props {
   softness?: number;
   intensity?: number;
   noise?: number;
+  /**
+   * Grain on narrow viewports. Defaults to a fraction of `noise` rather than a
+   * fixed value, so a caller that already dialled `noise` down (the CTA runs
+   * 0.12) is scaled rather than overridden upward.
+   *
+   * Grain is a per-pixel effect and phones render it at 3x: the same value that
+   * reads as texture on a desktop canvas reads as static on a phone, and it is
+   * the most expensive part of the shader to boot.
+   */
+  noiseNarrow?: number;
   speed?: number;
 }
 
@@ -34,12 +45,19 @@ export default function ShaderBackdrop({
   softness = 0.7,
   intensity = 0.15,
   noise = 0.5,
+  noiseNarrow = noise * 0.5,
   speed = 0.7,
 }: Props) {
   // Reduced motion: freeze rather than remove - the gradient is the art
   // direction; its drift is the only optional part. client:only guarantees
   // window exists by the time this runs.
   const still = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // Read once at mount, like `still` above. Deliberately not reactive: matching
+  // a resize would mean re-rendering the island, and remounting a WebGL canvas
+  // to change a grain constant is a bad trade for a rotation nobody does mid-
+  // scroll. 40rem is the same breakpoint the phone demo swaps at.
+  const narrow = window.matchMedia("(max-width: 40rem)").matches;
 
   return (
     <GrainGradient
@@ -48,7 +66,7 @@ export default function ShaderBackdrop({
       colorBack={colorBack}
       softness={softness}
       intensity={intensity}
-      noise={noise}
+      noise={narrow ? noiseNarrow : noise}
       shape="wave"
       speed={still ? 0 : speed}
     />

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -130,6 +130,11 @@ const jsonLd = {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    {/* No `viewport-fit=cover`, deliberately. It was tried for the band above
+        the hero and measured on-device: in normal Safari browsing the web view
+        already starts below the status bar, every env(safe-area-inset-*) reads
+        0, and the band is Safari's own chrome either way (see global.css). All
+        cover would add here is landscape notch insets we do not handle. */}
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <title>{pageTitle}</title>
@@ -255,9 +260,12 @@ const jsonLd = {
     </main>
     <Footer />
 
-    {/* Keeps the browser chrome in step with what is actually under it: dark
-        while the shader canvas holds the top of the viewport, the page ground
-        after it leaves. No-ops on every page without a [data-theme-anchor]. */}
+    {/* Keeps the browser chrome AND the document canvas background in step
+        with what is actually under them: dark while the shader canvas holds
+        the top of the viewport, the page ground after it leaves. body's
+        background is the only thing that reaches the band above the page on
+        iOS - see the note in global.css. No-ops on every page without a
+        [data-theme-anchor]. */}
     <script>
       const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
       const anchor = document.querySelector("[data-theme-anchor]");
@@ -265,12 +273,31 @@ const jsonLd = {
       const dark = meta?.dataset.dark;
 
       if (meta && anchor && light && dark) {
-        new IntersectionObserver(
-          ([entry]) => meta.setAttribute("content", entry.isIntersecting ? dark : light),
-          // Shrink the root's top edge by 1px so "not intersecting" means the
-          // anchor's last row of pixels has cleared the top of the viewport.
-          { rootMargin: "-1px 0px 0px 0px" },
-        ).observe(anchor);
+        // MEASURE the anchor; do not trust `entry.isIntersecting`.
+        //
+        // An IntersectionObserver delivers its first record as soon as it can,
+        // and engines differ on whether layout has settled by then. A record
+        // taken against a not-yet-laid-out anchor reports isIntersecting:false,
+        // which flips the bar to the LIGHT colour on a page whose hero is
+        // sitting right there in the viewport - and iOS Safari latches that
+        // first value, so the strip above the hero stays the page ground. Every
+        // callback re-measures instead, and a zero-height rect (layout not
+        // ready) says nothing at all rather than guessing wrong.
+        const sync = () => {
+          const rect = anchor.getBoundingClientRect();
+          if (rect.height === 0) return;
+          const holdsTop = rect.bottom > 0;
+          meta.setAttribute("content", holdsTop ? dark : light);
+          // Drives the canvas background too - see the [data-hero-top] note in
+          // global.css. An attribute rather than an inline style: the
+          // production CSP has no 'unsafe-inline' in style-src.
+          document.documentElement.toggleAttribute("data-hero-top", holdsTop);
+        };
+
+        requestAnimationFrame(sync);
+        // Shrink the root's top edge by 1px so a callback fires the moment the
+        // anchor's last row of pixels clears the top of the viewport.
+        new IntersectionObserver(sync, { rootMargin: "-1px 0px 0px 0px" }).observe(anchor);
       }
     </script>
   </body>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -638,6 +638,20 @@ const ENDOWMENT_VISUALS = [MailboxVisual, GitVisual, AutomationVisual, AgencyVis
      * can), which is what stops the two drifting apart. */
     .frame {
       padding: 0;
+
+      /* What shows THROUGH the canvas's rounded corners.
+       *
+       * <main> declares the page ground (global.css - body's own background is
+       * the signal that colours Safari's chrome, so it cannot also be paint),
+       * which left cream notches at the corners the moment the top pair stopped
+       * being square. The two ends want different answers: the top corners
+       * continue the dark strip above the page, the bottom corners meet the
+       * cream rails below. A hard stop past the radius gives each its own. */
+      background: linear-gradient(
+        to bottom,
+        var(--color-canvas) 2rem,
+        var(--color-ink) 2rem
+      );
     }
 
     .canvas {
@@ -645,9 +659,21 @@ const ENDOWMENT_VISUALS = [MailboxVisual, GitVisual, AutomationVisual, AgencyVis
        * depends on it (see --ph-crop). So the clip comes back here, where the
        * desktop window is display:none anyway. */
       overflow: hidden;
-      border-top: 0;
-      border-inline: 0;
-      border-radius: 0 0 clamp(1rem, 5vw, 1.75rem) clamp(1rem, 5vw, 1.75rem);
+      /* NO border at all here (owner, 2026-08-07). The top and sides went when
+       * the canvas became full-bleed - a hairline on an edge that coincides
+       * with the screen is just a line down the screen - and the bottom one
+       * follows now that all four corners are rounded, because a single edge
+       * of a rounded ring reads as an outline around the whole section. The
+       * canvas is still separated from the page by the thing that actually
+       * separates it: it is dark and the page is not. */
+      border: 0;
+      /* Rounded on all four corners now, not just the bottom. The top pair
+       * used to be square because a radius on an edge that touches the
+       * viewport shows the page ground through the corner - and the ground was
+       * cream. It is the canvas colour while the hero holds the top (see the
+       * [data-hero-top] note in global.css), so the corners now read as the
+       * shader being cut rather than as a leak. */
+      border-radius: clamp(1rem, 5vw, 1.75rem);
     }
 
     .hero-head {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -57,7 +57,15 @@
   --color-signal-canvas-deep: #f2808a; /* 7.28:1 */
 
   /* The dark canvas surfaces (hero, final CTA, dark visual panels). Warm
-   * black, same hue family as the OG card, used as the shader's colorBack. */
+   * black, same hue family as the OG card, used as the shader's colorBack.
+   *
+   * Owner tried #0f0e0c and reverted, 2026-08-07.
+   *
+   * If it is ever changed again, change it HERE and nowhere else: <body>
+   * carries this same value while the hero holds the top of the viewport -
+   * that is what colours Safari's chrome above the page - and
+   * ShaderBackdrop.tsx keeps its own copy as the shader's ground. All three
+   * have to move together or the seam where the canvas ends becomes visible. */
   --color-canvas: #141311;
   --color-canvas-text: #f7f5f1;
 
@@ -127,6 +135,42 @@
 
 :root {
   color-scheme: light;
+}
+
+/* THE STRIP ABOVE THE PAGE ON iOS SAFARI.
+ *
+ * That band is Safari's own chrome, not the page: in normal browsing the web
+ * view starts BELOW it, which is why env(safe-area-inset-top) measured 0 on
+ * device even with viewport-fit=cover. The page cannot paint there. All it can
+ * do is tell Safari what colour to use, and Safari's order of preference is:
+ *
+ *   1. a fixed/sticky element's background-color
+ *   2. <body>'s background-color        <- the one that decides it here
+ *   3. <meta name="theme-color">        <- deprecated, ignored from iOS 26
+ *   4. the web app manifest
+ *
+ * So theme-color was never going to work, and neither was <html> - body's
+ * background wins over it. Which means body's colour has to become a SIGNAL
+ * rather than paint: main and footer below declare the page ground themselves,
+ * so body's own value is never visible and is free to say "the thing at the
+ * top of the viewport is dark".
+ *
+ * Base.astro's sync sets [data-hero-top] for exactly as long as the dark
+ * canvas holds the top. The bottom overscroll would also take this colour, but
+ * on a page taller than the viewport you cannot be at the hero and
+ * rubber-banding the footer at once, so the two states never collide. */
+html[data-hero-top] body {
+  background-color: var(--color-canvas);
+}
+
+/* The reader's ground, declared where it is painted rather than inherited from
+ * body - see above for why body's own background is not available for this.
+ *
+ * `body > footer`, not `footer`: the hero demo's composer is a <footer> too,
+ * and a bare element selector would hand it the page ground. */
+main,
+body > footer {
+  background-color: var(--color-ink);
 }
 
 /* Hoists the hero canvas's view timeline (declared in index.astro) up to


### PR DESCRIPTION
This pull request enhances the interactive demo experience in `AppDemo.astro`, improves accessibility and polish in the UI, and fixes animation and shader behaviors for better cross-browser and device support. The most significant changes include enabling live message sending in the demo UI, refining animation and style behaviors for both desktop and mobile, and improving the logic for agent replies and visual consistency.

**Demo interactivity and agent reply logic:**

- Added support for sending messages in the demo chat UI: pressing Enter or clicking the send button appends a user message and triggers a simulated agent/channel reply, with the reply logic now reflecting the last agent in the conversation and offering a call-to-action link instead of a canned response. [[1]](diffhunk://#diff-a8c0c582a8a2127e39ed28b3a12883753e18f6330ee3ed302a635b41ac3d21ccR73-R89) [[2]](diffhunk://#diff-a8c0c582a8a2127e39ed28b3a12883753e18f6330ee3ed302a635b41ac3d21ccL648-R672) [[3]](diffhunk://#diff-a8c0c582a8a2127e39ed28b3a12883753e18f6330ee3ed302a635b41ac3d21ccL862-R1017) [[4]](diffhunk://#diff-a8c0c582a8a2127e39ed28b3a12883753e18f6330ee3ed302a635b41ac3d21ccR1029-R1033)
- Added `data-reply-name` and `data-reply-ava` attributes to conversation sections for accurate reply attribution, and improved the logic for determining which agent replies in each context.

**UI/UX improvements:**

- Improved message arrival animation for sent and received messages, and ensured that new messages animate in while server-rendered threads do not replay the animation.
- Adjusted margins and padding for conversation cards and message feeds to improve layout, especially at the bottom of the chat window where the composer floats. [[1]](diffhunk://#diff-a8c0c582a8a2127e39ed28b3a12883753e18f6330ee3ed302a635b41ac3d21ccL1327-R1474) [[2]](diffhunk://#diff-a8c0c582a8a2127e39ed28b3a12883753e18f6330ee3ed302a635b41ac3d21ccL2225-R2394)
- Enhanced the send button's interaction feedback and accessibility, including pointer and press states, and ensured the button is only clickable when appropriate.

**Cross-browser/device polish:**

- Fixed scroll-driven animation issues in `PhoneDemo.astro` by avoiding the `animation` shorthand (which could be minified away), setting explicit longhand properties, and providing a static fallback for browsers without scroll-timeline support. [[1]](diffhunk://#diff-fd548d1d12c41ca4dcfd712643f0d1fe05ea1a4cd8e2ce803a9fe413a9475b52R1422-R1443) [[2]](diffhunk://#diff-fd548d1d12c41ca4dcfd712643f0d1fe05ea1a4cd8e2ce803a9fe413a9475b52R1456-R1464)
- Improved the shader backdrop (`ShaderBackdrop.tsx`) by allowing a separate grain/noise value for narrow viewports (mobile), and clarified documentation to prevent visual seams between the shader and the page background. [[1]](diffhunk://#diff-c55350e30503bd8d7e3965d08299b4e7c9becd72950c84ae29f90ff02b334223L19-R20) [[2]](diffhunk://#diff-c55350e30503bd8d7e3965d08299b4e7c9becd72950c84ae29f90ff02b334223R29-R38) [[3]](diffhunk://#diff-c55350e30503bd8d7e3965d08299b4e7c9becd72950c84ae29f90ff02b334223R48-R69)

**Accessibility and browser integration:**

- Enhanced the viewport and theme color handling in `Base.astro`, including a more robust IntersectionObserver callback for updating browser and canvas backgrounds in sync with the hero section, and clarified the rationale for not using `viewport-fit=cover`. [[1]](diffhunk://#diff-c91526002da0b02ceaabb10349f15844c730cec130efad6ee971c6d9a359b60eR133-R137) [[2]](diffhunk://#diff-c91526002da0b02ceaabb10349f15844c730cec130efad6ee971c6d9a359b60eL258-R300)