### PR TITLE
fix mobile pages - changelog, downloads

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -525,11 +525,17 @@ html[data-tauri-platform="linux"] body {
   }
 
   /* Skip link - the app had none on any route. Visually hidden until focused,
-   * then pinned to the top-left above all app chrome (the rail sits at z-40).
-   * Clears the Tauri title bar so it never lands under the traffic lights. */
+   * then pinned to the top-left above all app chrome (the rail sits at z-40),
+   * below the Tauri title bar so it never lands under the traffic lights.
+   *
+   * The resting `top` is 0 and the title-bar clearance is applied by the
+   * *focused* transform, NOT by `top`. Doing it the other way round (top =
+   * titlebar-height + gap, hidden via translateY(-100% - gap)) only clears the
+   * viewport while --titlebar-height is 0px: on the desktop app it is 38px, so
+   * the pill came to rest 30px on-screen and sat over the traffic lights. */
   .skip-link {
     position: fixed;
-    top: calc(var(--titlebar-height) + 0.5rem);
+    top: 0;
     left: 0.5rem;
     z-index: 60;
     padding: 0.5rem 0.875rem;
@@ -539,11 +545,11 @@ html[data-tauri-platform="linux"] body {
     box-shadow: var(--shadow-lg);
     font-size: 0.875rem;
     font-weight: 500;
-    transform: translateY(calc(-100% - 1rem));
+    transform: translateY(-100%);
     transition: transform 150ms ease;
   }
   .skip-link:focus-visible {
-    transform: translateY(0);
+    transform: translateY(calc(var(--titlebar-height) + 0.5rem));
   }
 
   /* Remove the legacy 300ms tap delay + double-tap zoom on controls while

--- a/web/src/pages/brand.astro
+++ b/web/src/pages/brand.astro
@@ -562,6 +562,63 @@ const boilerplate = SITE.description;
     color: color-mix(in srgb, var(--color-canvas-text) 52%, transparent);
   }
 
+  /* Narrow screens turn the canvas PORTRAIT, and the shader's wave is sized to
+   * the canvas - so the same band that sits low and wide on desktop rears up
+   * and fills the frame behind the copy. The radial pool above assumes a tall
+   * dark field it no longer has, so it is swapped for a flat top-down wash
+   * that covers the bottom half, where the wave is brightest. Same correction,
+   * same values, as /download and /changelog. */
+  @media (max-width: 48rem) {
+    .cover {
+      padding-block: clamp(5rem, 18vw, 5.75rem) clamp(2.75rem, 9vw, 3.5rem);
+    }
+
+    .shader::after {
+      background: linear-gradient(
+        to bottom,
+        rgb(20 19 17 / 0.68) 0%,
+        rgb(20 19 17 / 0.5) 45%,
+        rgb(20 19 17 / 0.34) 100%
+      );
+    }
+  }
+
+  /* ── Phones: the cover canvas goes full-bleed ─────────────────────────
+   * The homepage's hero treatment at the same 40rem breakpoint, for the same
+   * reason: below this width Nav.astro drops the overlay header's 1rem inset
+   * and aligns it to --hero-gutter, so a cover that stays inside a framed card
+   * puts the wordmark and the title on two different left edges. See
+   * download.astro for the long version - /download, /changelog and /brand
+   * all carry this block. */
+  @media (max-width: 40rem) {
+    .frame {
+      padding: 0;
+      /* Fills the rounded corners: canvas colour above, page ground below. */
+      background: linear-gradient(
+        to bottom,
+        var(--color-canvas) 2rem,
+        var(--color-ink) 2rem
+      );
+    }
+
+    .canvas {
+      border: 0;
+      border-radius: clamp(1rem, 5vw, 1.75rem);
+    }
+
+    /* The one difference from the other two heads: this is a flex column, so
+     * the cross-axis alignment has to move with the text alignment or the
+     * button and the meta line stay centred under left-aligned copy. */
+    .cover {
+      align-items: flex-start;
+      text-align: left;
+      padding-inline: var(--hero-gutter);
+      /* Full-bleed puts the overlay header at y=0 rather than 1rem down, so
+       * the 48rem block's 5rem left the title sitting under the wordmark. */
+      padding-top: clamp(6.5rem, 20vw, 7.5rem);
+    }
+  }
+
   /* ── Rails ──────────────────────────────────────────────────────────── */
   /* 70.5rem, the same measure the homepage rails use, so /brand lines up with
    * every other page rather than running its own narrower column. */

--- a/web/src/pages/changelog/index.astro
+++ b/web/src/pages/changelog/index.astro
@@ -485,8 +485,12 @@ const schema = [
     border-top: 1px solid var(--color-line);
   }
 
+  /* 60rem, the rails' measure - not the homepage's 70.5rem. The closing line
+   * runs full-bleed, but the sentence under it belongs to this page's column,
+   * and at 70.5rem it started a full 5rem to the left of every release above
+   * it. */
   .tail-inner {
-    max-width: 70.5rem;
+    max-width: 60rem;
     margin-inline: auto;
     padding: clamp(2rem, 4vw, 3rem) clamp(1.25rem, 4vw, 3rem);
     font-size: 0.9375rem;
@@ -526,6 +530,43 @@ const schema = [
         rgb(20 19 17 / 0.5) 45%,
         rgb(20 19 17 / 0.34) 100%
       );
+    }
+  }
+
+  /* ── Phones: the head canvas goes full-bleed ──────────────────────────
+   * The homepage's hero treatment at the same 40rem breakpoint, for the same
+   * reason: below this width Nav.astro drops the overlay header's 1rem inset
+   * and aligns it to --hero-gutter, so a head that stays inside a framed card
+   * puts the wordmark and the headline on two different left edges. See
+   * download.astro for the long version - /download, /changelog and /brand
+   * all carry this block. */
+  @media (max-width: 40rem) {
+    .frame {
+      padding: 0;
+      /* Fills the rounded corners: canvas colour above, page ground below. */
+      background: linear-gradient(
+        to bottom,
+        var(--color-canvas) 2rem,
+        var(--color-ink) 2rem
+      );
+    }
+
+    .canvas {
+      border: 0;
+      border-radius: clamp(1rem, 5vw, 1.75rem);
+      box-shadow: none;
+    }
+
+    .head {
+      text-align: left;
+      padding-inline: var(--hero-gutter);
+      /* Full-bleed puts the overlay header at y=0 rather than 1rem down, so
+       * the 48rem block's 5rem left the badge sitting under the wordmark. */
+      padding-top: clamp(6.5rem, 20vw, 7.5rem);
+    }
+
+    .head .lede {
+      margin-inline: 0;
     }
   }
 

--- a/web/src/pages/download.astro
+++ b/web/src/pages/download.astro
@@ -665,4 +665,58 @@ const schema = [
       --stack-gap: 0.75rem;
     }
   }
+
+  /* ── Phones: the head canvas goes full-bleed ──────────────────────────
+   *
+   * The homepage's hero does this at the same 40rem breakpoint, and the
+   * reason it has to be repeated here is Nav.astro: below 40rem the overlay
+   * header drops its own 1rem inset and sets its inner padding to
+   * --hero-gutter, i.e. it aligns to the VIEWPORT rather than to a framed
+   * canvas. A head that stays inset then leaves the wordmark half a rem
+   * from a rounded corner while the headline sits 3.5rem in - two different
+   * left edges in the same 375px band.
+   *
+   * So: the frame goes, the head joins the same gutter line, and the copy
+   * turns left-aligned to sit ON that line the way the homepage's does. See
+   * index.astro's matching block for the full argument; the notes here are
+   * only what differs. Same treatment on /changelog and /brand. */
+  @media (max-width: 40rem) {
+    .frame {
+      padding: 0;
+      /* What shows THROUGH the canvas's rounded corners: <main> declares the
+       * cream page ground, which would otherwise notch all four of them. The
+       * top pair continue the dark strip above the page, the bottom pair meet
+       * the rails below - a hard stop past the radius gives each its own. */
+      background: linear-gradient(
+        to bottom,
+        var(--color-canvas) 2rem,
+        var(--color-ink) 2rem
+      );
+    }
+
+    .canvas {
+      /* No border and no shadow once the sides coincide with the screen:
+       * a hairline on an edge that IS the viewport edge is just a line down
+       * the screen, and a drop shadow has nothing to cast onto. */
+      border: 0;
+      border-radius: clamp(1rem, 5vw, 1.75rem);
+      box-shadow: none;
+    }
+
+    .head {
+      text-align: left;
+      padding-inline: var(--hero-gutter);
+      /* More headroom than the 48rem block gives, because the nav moved. On a
+       * framed canvas the overlay header starts 1rem down and its own 4rem row
+       * ends well inside the head's padding; full-bleed it starts at y=0, so
+       * 5rem of padding left the headline 16px under the wordmark. This is the
+       * homepage hero's clearance, scaled to this page's shorter head. */
+      padding-top: clamp(6.5rem, 20vw, 7.5rem);
+    }
+
+    /* Centred margins are what held these away from the gutter line. */
+    .head .lede {
+      margin-inline: 0;
+    }
+  }
 </style>


### PR DESCRIPTION
This pull request focuses on improving layout consistency and responsive design across several pages, especially for mobile and desktop platforms. The main themes are: (1) fixing the skip link placement in the Linux desktop app, (2) harmonizing column widths, and (3) ensuring full-bleed hero/cover sections and correct text alignment on small screens for `/download`, `/changelog`, and `/brand`.

**Accessibility and Desktop App Fixes:**

* The `.skip-link` is now always visually hidden at the top of the viewport and, when focused, moves below the Tauri title bar using a transform instead of a `top` offset. This prevents the skip link from overlapping desktop window controls on Linux. [[1]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L528-R538) [[2]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L542-R552)

**Layout Consistency:**

* The `.tail-inner` container on the `/changelog` page now uses a `max-width` of 60rem (matching the rails), instead of the homepage's wider 70.5rem, ensuring better column alignment.

**Responsive Design Improvements (Grouped by Page):**

* `/download`, `/changelog`, and `/brand` pages now apply a full-bleed hero/cover treatment on screens narrower than 40rem. This includes:
  - Removing frame padding and background, letting the canvas go edge-to-edge.
  - Removing borders and box-shadows from canvases.
  - Left-aligning text and aligning padding to the overlay header gutter, so the wordmark and headline share a clean left edge.
  - Adjusting vertical padding for improved spacing below the overlay header.
  - Removing centered margins from lede text. [[1]](diffhunk://#diff-0baeec10bb663c7f24f9bce937ceb506038719db19ad986717efe49aeee2b972R668-R721) [[2]](diffhunk://#diff-f13b79d8baf924f487bb61af7a2e7bd311bd6021fa07423baa02337b197d18b3R536-R572) [[3]](diffhunk://#diff-9bf38e783819d126fc469e305d54ad349ac053abce6189797a90042ff537d26dR565-R621)

* On `/brand`, for screens narrower than 48rem, the background behind the shader is adjusted to ensure the wave effect doesn't overpower the content, matching the treatments on `/download` and `/changelog`.

These changes ensure a more polished, consistent, and accessible user experience across devices and platforms.