### PR TITLE
Chat correctness pass: attachment-only quotes, honest channel previews, non-occluding attachment viewer

### DIFF
--- a/apps/mobile/src/app/(tabs)/chats/[channelId].tsx
+++ b/apps/mobile/src/app/(tabs)/chats/[channelId].tsx
@@ -65,6 +65,7 @@ import {
   type MmPost,
 } from '@/lib/api';
 import { buildChatRows, type ChatRow } from '@/lib/chat-grouping';
+import { quotedBodyText } from '@/lib/formatting';
 import { useAuth } from '@/providers/auth-provider';
 import { useRealtime } from '@/providers/realtime-provider';
 import { useTabBarVisibility } from '@/providers/tab-bar-visibility';
@@ -659,6 +660,7 @@ export default function ChannelScreen() {
             poster_display_name: replyParent.poster_display_name,
             message_excerpt: replyParent.message.slice(0, 140),
             status: replyParent.status,
+            attachment_count: replyParent.files?.length ?? 0,
           }
         : null,
       fileIds,
@@ -958,7 +960,9 @@ export default function ChannelScreen() {
               replyTo
                 ? {
                     authorName: replyTo.poster_display_name ?? 'Unknown',
-                    excerpt: replyTo.message,
+                    // Attachment-only parents carry no text — the banner
+                    // labels them from the file count instead of blank.
+                    excerpt: quotedBodyText(replyTo.message, replyTo.files?.length ?? 0),
                     onCancel: () => setReplyTo(null),
                   }
                 : undefined

--- a/apps/mobile/src/components/chat/message-bubble.tsx
+++ b/apps/mobile/src/components/chat/message-bubble.tsx
@@ -29,6 +29,7 @@ import { useTheme } from '@/hooks/use-theme';
 import type { MessageRow } from '@/lib/chat-grouping';
 import { matchAdminCommandText, type AdminCommandMatch } from '@/lib/admin-commands';
 import { extractUrls } from '@/lib/extract-urls';
+import { quotedBodyText } from '@/lib/formatting';
 
 const IMESSAGE_BLUE = '#0A84FF';
 const INCOMING_LIGHT = '#E9E9EB';
@@ -403,7 +404,11 @@ function ParentQuote({ preview, isOutgoing, onPress }: ParentQuoteProps) {
     preview.poster_display_name ??
     preview.agent_id ??
     (preview.human_id != null ? `User ${preview.human_id}` : 'Unknown');
-  const excerpt = removed ? 'Original message removed' : preview.message_excerpt;
+  // An attachment-only parent has no text to quote — label it from the
+  // file count rather than leaving the excerpt line blank.
+  const excerpt = removed
+    ? 'Original message removed'
+    : quotedBodyText(preview.message_excerpt, preview.attachment_count ?? 0);
 
   // The quote sits inside the bubble; tone it as a darker/lighter
   // overlay on the bubble's own bg so it reads as a nested zone.
@@ -439,7 +444,7 @@ function ParentQuote({ preview, isOutgoing, onPress }: ParentQuoteProps) {
             removed && styles.quoteRemoved,
           ]}
           numberOfLines={1}>
-          {excerpt || '(empty message)'}
+          {excerpt}
         </Text>
       </View>
     </Pressable>

--- a/apps/mobile/src/components/chat/message-composer.tsx
+++ b/apps/mobile/src/components/chat/message-composer.tsx
@@ -254,7 +254,7 @@ export function MessageComposer({
             <Text
               style={[styles.replyExcerpt, { color: theme.textSecondary }]}
               numberOfLines={1}>
-              {replyingTo.excerpt || 'Attachment'}
+              {replyingTo.excerpt}
             </Text>
           </View>
           <Pressable

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -366,6 +366,10 @@ export interface MmPostParentPreview {
   poster_display_name: string | null;
   message_excerpt: string;
   status: MmPostStatus;
+  /** Uploaded files on the parent post. Lets the quote render an
+   *  attachment-only parent (which legitimately has no text) with a
+   *  label instead of a blank line. Absent on legacy payloads → 0. */
+  attachment_count?: number;
 }
 
 /** Server-resolved OG card embedded on a post at create / edit time.

--- a/apps/mobile/src/lib/formatting.ts
+++ b/apps/mobile/src/lib/formatting.ts
@@ -1,5 +1,21 @@
 import { type HumanUser } from '@/lib/api';
 
+/** One-line stand-in for a message body that has no text. A post is
+ *  allowed to be attachment-only, so anywhere a body is quoted at
+ *  one-line size — the composer's reply banner, the quote above a
+ *  reply bubble — an empty body means "attachments", not "nothing".
+ *  Wording matches the channel-list previews. */
+export function attachmentOnlyLabel(count: number): string | null {
+  if (count <= 0) return null;
+  return count === 1 ? 'Attachment' : `${count} attachments`;
+}
+
+/** Text to render for a quoted message body: its own text when it has
+ *  any, else an attachment label, else a last-resort placeholder. */
+export function quotedBodyText(text: string, attachmentCount: number): string {
+  return text.trim() || attachmentOnlyLabel(attachmentCount) || '(empty message)';
+}
+
 export function formatChannelTitle(value: string): string {
   return value
     .replace(/^agent-/u, '')

--- a/apps/mobile/src/lib/realtime-handlers.ts
+++ b/apps/mobile/src/lib/realtime-handlers.ts
@@ -58,10 +58,18 @@ export function applyRealtimeEvent(
     case 'channel.read':
       applyChannelRead(queryClient, event);
       return;
+    case 'post.deleted':
+      // The deleted post may have been the channel's denormalised
+      // last-message snapshot. We can't recompute the replacement
+      // preview from the event payload (it only carries the post id),
+      // so refetch the list and let the server answer. Cheap and rare
+      // — deletes are user-initiated, never streamed.
+      void queryClient.invalidateQueries({ queryKey: CHANNELS_KEY });
+      return;
     // Events handled elsewhere or intentionally ignored on the global
     // stream:
-    // - 'post.updated'/'post.deleted': only matter inside a channel,
-    //   which has its own per-channel SSE consumer.
+    // - 'post.updated': only matters inside a channel, which has its
+    //   own per-channel SSE consumer.
     // - 'member.status'/'member.read'/'presence.snapshot': per-channel
     //   only; never arrive here.
     // - 'user.status': no UI consumes presence cross-channel yet.

--- a/clawbits/datastructures/mm_models.py
+++ b/clawbits/datastructures/mm_models.py
@@ -346,6 +346,11 @@ class MmPostParentPreview(BaseModel):
     stays bounded even when the parent is a 4000-char post. ``status`` is
     included so the client can degrade gracefully when the parent was
     rejected (renders as "Original message removed").
+
+    ``attachment_count`` is the number of uploaded files on the parent.
+    A post is allowed to carry files with no text at all, so without it
+    the quote-block had no way to tell "attachment-only message" from
+    "genuinely blank" and rendered a misleading "(empty message)".
     """
     post_id: int
     agent_id: str | None = None
@@ -353,6 +358,7 @@ class MmPostParentPreview(BaseModel):
     poster_display_name: str | None = None
     message_excerpt: str
     status: MmPostStatus
+    attachment_count: int = 0
 
 
 MmFileStatus = Literal["pending", "uploaded", "failed", "deleted"]

--- a/clawbits/db/table_read.py
+++ b/clawbits/db/table_read.py
@@ -1781,6 +1781,17 @@ class TableRead:
         excerpt = (parent.message or "").strip()
         if len(excerpt) > TableRead._PARENT_EXCERPT_LIMIT:
             excerpt = excerpt[: TableRead._PARENT_EXCERPT_LIMIT - 1].rstrip() + "…"
+        # A post with files needs no text (see MmPostRequest's validator), so
+        # the quote-block needs the count to label an attachment-only parent
+        # instead of rendering it as blank. Count only — the file metadata
+        # itself is never needed at quote size.
+        attachment_count = int(
+            session.exec(
+                select(func.count(MmFile.file_id))
+                .where(MmFile.post_id == parent.post_id)
+                .where(MmFile.status == "uploaded")
+            ).one()
+        )
         return {
             "post_id": parent.post_id,
             "agent_id": parent.agent_id,
@@ -1788,6 +1799,7 @@ class TableRead:
             "poster_display_name": display,
             "message_excerpt": excerpt,
             "status": parent.status,
+            "attachment_count": attachment_count,
         }
 
     @staticmethod

--- a/clawbits/db/table_write.py
+++ b/clawbits/db/table_write.py
@@ -2658,6 +2658,10 @@ class TableWrite:
             post.link_preview = link_preview
         session.add(post)
         session.flush()
+        # Keep the channel's denormalised sidebar preview honest: editing
+        # the newest message would otherwise leave the pre-edit text in the
+        # chats list forever. A no-op for older posts.
+        TableWrite._recompute_channel_preview(session, post.channel_id)
         return post
 
     @staticmethod
@@ -2735,6 +2739,13 @@ class TableWrite:
 
         session.delete(post)
         session.flush()
+        # The channel's denormalised sidebar preview may have been pointing
+        # at this exact row — rebuild it from what's left so the snippet
+        # doesn't outlive the message it came from. Unconditional rather
+        # than gated on "was this the latest post?": one indexed lookup on
+        # a rare, user-initiated action is cheaper than the bug class where
+        # the guard and the read path's notion of "latest" drift apart.
+        TableWrite._recompute_channel_preview(session, snapshot.channel_id)
         return snapshot
 
     @staticmethod

--- a/frontend/src/components/AttachmentViewer.tsx
+++ b/frontend/src/components/AttachmentViewer.tsx
@@ -32,6 +32,20 @@ interface AttachmentViewerProps {
   onClose: () => void;
 }
 
+/** Height of the viewport-anchored top bar. The media size budget subtracts
+ *  it so the chrome can never end up sitting on the picture. Keep in sync
+ *  with the bar's ``h-14`` class. */
+const CHROME_H = "3.5rem";
+/** Room held back on each side for the prev/next chevrons, as a custom
+ *  property the image's width budget subtracts. Set only when there is
+ *  something to page to, and only from ``sm`` up: on a phone-width viewport
+ *  two 7rem gutters would eat most of the picture, so there the chevrons go
+ *  back to floating over the image's left/right edges (its least
+ *  content-dense strip) rather than shrinking it. */
+const NAV_GUTTER = "[--nav-w:0px] sm:[--nav-w:7rem]";
+/** Idle delay before the chrome fades down to a quiet state. */
+const IDLE_MS = 2500;
+
 /**
  * Full-screen, type-aware attachment viewer. Supersedes the image-only
  * lightbox: pages through ``files`` with ←/→, Esc closes, the backdrop
@@ -41,12 +55,17 @@ interface AttachmentViewerProps {
  * never executed). Anything else falls back to a download card.
  *
  * Chrome (filename + counter pill, action pill, chevrons, portal-to-body,
- * ``data-state="open"`` so page-level Esc handlers defer to it).
+ * ``data-state="open"`` so page-level Esc handlers defer to it) lives in a
+ * bar *outside* the media plus gutters beside it, with the media's size
+ * budget reserving that space, so no control is painted over the content
+ * (the one exception being the chevrons on a phone-width viewport — see
+ * ``NAV_GUTTER``). It fades to a quiet state while the user is just looking.
  */
 export function AttachmentViewer({ files, initialIndex, onClose }: AttachmentViewerProps) {
   const [index, setIndex] = useState(initialIndex);
   const current = files[index];
   const dialogRef = useRef<HTMLDivElement>(null);
+  const idle = useIdle(IDLE_MS);
 
   useEffect(() => {
     const prev = document.body.style.overflow;
@@ -135,56 +154,59 @@ export function AttachmentViewer({ files, initialIndex, onClose }: AttachmentVie
   };
 
   const isImageKind = previewKind(current.filename, current.content_type) === "image";
+  const multiple = files.length > 1;
 
-  // Floating controls. For an image they sit on top of the image itself (the
-  // image is the surface); for other types they sit on the contained panel.
-  const chrome = (
-    <ViewerChrome
-      filename={current.filename}
-      index={index}
-      count={files.length}
-      onClose={onClose}
-      onDownload={() => { void download(); }}
-      onPrev={goPrev}
-      onNext={goNext}
-    />
-  );
+  const nav = multiple ? <ViewerNav idle={idle} onPrev={goPrev} onNext={goNext} /> : null;
 
   return createPortal(
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className="fixed inset-0 z-50 bg-black/70 backdrop-blur-md outline-none"
+      className="fixed inset-0 z-50 flex flex-col bg-black/70 backdrop-blur-md outline-none"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
       aria-label={current.filename}
       data-state="open"
     >
+      {/* The bar owns its own row, so the media below it starts where the bar
+          ends and no control is ever painted over the content. */}
+      <ViewerTopBar
+        filename={current.filename}
+        index={index}
+        count={files.length}
+        idle={idle}
+        onClose={onClose}
+        onDownload={() => { void download(); }}
+      />
+
       {isImageKind ? (
-        // The image is the surface: it sizes to its own aspect ratio and the
-        // controls float on top of *it*, not the viewport, so the viewer reads
-        // as one minimal image rather than a full-screen UI. ``relative flex``
-        // shrink-wraps the wrapper to the image so the chrome anchors to its
-        // corners. A click on the backdrop (or the image) bubbles to onClose.
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="relative flex">
-            <ViewerContent key={current.file_id} file={current} onDownload={download} />
-            {chrome}
-          </div>
+        // The image is the surface: it sizes to its own aspect ratio inside
+        // the space the bar left over, so the viewer still reads as one
+        // minimal image rather than a full-screen UI. ``pb-14`` mirrors the
+        // bar's row so the picture stays centred on the viewport instead of
+        // being pushed low by it. A click on the backdrop (or the image)
+        // bubbles to onClose.
+        <div
+          className={`relative flex min-h-0 flex-1 items-center justify-center pb-14 ${
+            multiple ? NAV_GUTTER : ""
+          }`}
+        >
+          <ViewerContent key={current.file_id} file={current} onDownload={download} />
+          {nav}
         </div>
       ) : (
         // Non-image surfaces (video / pdf / text / fallback) keep a contained,
         // rounded panel; ``stopPropagation`` so interacting with them doesn't
         // close the viewer.
         <div
-          className="absolute inset-4 flex items-center justify-center overflow-hidden rounded-2xl border border-white/15 bg-black/30 shadow-2xl sm:inset-6 md:inset-10"
+          className="relative mx-4 mb-4 flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-2xl border border-white/15 bg-black/30 shadow-2xl sm:mx-6 sm:mb-6 md:mx-10 md:mb-10"
           onClick={(e) => { e.stopPropagation(); }}
         >
           {/* Per-file content. ``key`` resets the inner fetch/blob state when
               the user navigates to a different attachment. */}
           <ViewerContent key={current.file_id} file={current} onDownload={download} />
-          {chrome}
+          {nav}
         </div>
       )}
     </div>,
@@ -194,33 +216,70 @@ export function AttachmentViewer({ files, initialIndex, onClose }: AttachmentVie
 
 // ---------------------------------------------------------------------------
 
-/** Floating controls overlaid on the active surface — filename + counter
- *  (top-left), download + close (top-right), and prev/next chevrons. Buttons
- *  ``stopPropagation`` so a tap on a control never also triggers the backdrop
- *  close. Positioned ``absolute`` so it anchors to whatever wraps it — the
- *  image itself, or the contained panel for other file types. */
-function ViewerChrome({
+/** True once ``delay`` ms have passed with no pointer or keyboard activity;
+ *  any input wakes it back up. Drives the quiet-down of the chrome while the
+ *  user is just looking at the picture. */
+function useIdle(delay: number) {
+  const [idle, setIdle] = useState(false);
+  useEffect(() => {
+    let timer = window.setTimeout(() => { setIdle(true); }, delay);
+    const wake = () => {
+      // React bails out when the value is unchanged, so the common case
+      // (moving the pointer while already awake) costs no render.
+      setIdle(false);
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => { setIdle(true); }, delay);
+    };
+    const events = ["pointermove", "pointerdown", "keydown", "wheel"] as const;
+    for (const e of events) window.addEventListener(e, wake, { passive: true });
+    return () => {
+      window.clearTimeout(timer);
+      for (const e of events) window.removeEventListener(e, wake);
+    };
+  }, [delay]);
+  return idle;
+}
+
+/** Idle styling for a chrome group: fades down but never out, so the controls
+ *  stay discoverable. Keyboard focus always restores full opacity, and users
+ *  who asked for reduced motion never see the fade at all. */
+function dimClass(idle: boolean) {
+  // Variant utilities are emitted after their plain counterparts, so
+  // ``focus-within:``/``motion-reduce:`` win over ``opacity-40`` on their own.
+  return `transition-opacity duration-300 focus-within:opacity-100 motion-reduce:opacity-100 motion-reduce:transition-none ${
+    idle ? "opacity-40" : "opacity-100"
+  }`;
+}
+
+// ---------------------------------------------------------------------------
+
+/** The viewer's own row above the media — filename + counter on the left,
+ *  download + close on the right. It occupies layout (``h-14``, matching
+ *  ``CHROME_H``) rather than floating, so it can never occlude the content.
+ *  Buttons ``stopPropagation`` so a tap on a control never also triggers the
+ *  backdrop close; empty bar space still closes, like the rest of the
+ *  backdrop. */
+function ViewerTopBar({
   filename,
   index,
   count,
+  idle,
   onClose,
   onDownload,
-  onPrev,
-  onNext,
 }: {
   filename: string;
   index: number;
   count: number;
+  idle: boolean;
   onClose: () => void;
   onDownload: () => void;
-  onPrev: () => void;
-  onNext: () => void;
 }) {
   const multiple = count > 1;
   return (
-    <>
-      {/* Top-left: filename + counter. */}
-      <div className="pointer-events-none absolute left-3 top-3 z-10 flex max-w-[70%] items-center gap-2 rounded-full bg-black/50 px-3 py-1.5 text-sm text-white/90 backdrop-blur-md">
+    <div
+      className={`flex h-14 shrink-0 items-center justify-between gap-3 px-3 ${dimClass(idle)}`}
+    >
+      <div className="pointer-events-none flex min-w-0 items-center gap-2 rounded-full bg-black/50 px-3 py-1.5 text-sm text-white/90 backdrop-blur-md">
         <span className="truncate font-medium">{filename}</span>
         {multiple && (
           <span className="shrink-0 rounded-full bg-white/10 px-2 py-0.5 text-[11px] font-medium text-white/80">
@@ -229,8 +288,7 @@ function ViewerChrome({
         )}
       </div>
 
-      {/* Top-right: actions. */}
-      <div className="absolute right-3 top-3 z-10 flex items-center gap-0.5 rounded-full bg-black/50 p-1 backdrop-blur-md">
+      <div className="flex shrink-0 items-center gap-0.5 rounded-full bg-black/50 p-1 backdrop-blur-md">
         <button
           type="button"
           onClick={(e) => { e.stopPropagation(); onDownload(); }}
@@ -248,28 +306,43 @@ function ViewerChrome({
           <Icon icon={Cancel01Icon} className="size-4" />
         </button>
       </div>
+    </div>
+  );
+}
 
-      {multiple && (
-        <>
-          <button
-            type="button"
-            onClick={(e) => { e.stopPropagation(); onPrev(); }}
-            aria-label="Previous"
-            className="absolute left-3 top-1/2 z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white/85 backdrop-blur-md transition-colors hover:bg-black/70 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
-          >
-            <Icon icon={ArrowLeft01Icon} className="size-5" />
-          </button>
-          <button
-            type="button"
-            onClick={(e) => { e.stopPropagation(); onNext(); }}
-            aria-label="Next"
-            className="absolute right-3 top-1/2 z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white/85 backdrop-blur-md transition-colors hover:bg-black/70 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
-          >
-            <Icon icon={ArrowRight01Icon} className="size-5" />
-          </button>
-        </>
-      )}
-    </>
+/** Prev/next chevrons, centred on the media area. For images the media
+ *  reserves ``--nav-w`` on each side so these land in the backdrop gutters
+ *  instead of on the picture. */
+function ViewerNav({
+  idle,
+  onPrev,
+  onNext,
+}: {
+  idle: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  const cls =
+    "absolute top-1/2 z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/50 text-white/85 backdrop-blur-md transition-colors hover:bg-black/70 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40";
+  return (
+    <div className={`pointer-events-none absolute inset-0 z-10 ${dimClass(idle)}`}>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onPrev(); }}
+        aria-label="Previous"
+        className={`pointer-events-auto left-3 ${cls}`}
+      >
+        <Icon icon={ArrowLeft01Icon} className="size-5" />
+      </button>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onNext(); }}
+        aria-label="Next"
+        className={`pointer-events-auto right-3 ${cls}`}
+      >
+        <Icon icon={ArrowRight01Icon} className="size-5" />
+      </button>
+    </div>
   );
 }
 
@@ -361,20 +434,28 @@ function ImageContent({ file }: { file: MmFile }) {
 
   const src = fullReady && full ? full : (thumb ?? full ?? "");
 
-  // Pin the displayed box to the file's known aspect ratio fitted into the
-  // viewport, so it's identical whether the cached thumbnail or the full-res
+  // The space the chrome left over: the top bar's row is already gone from the
+  // flex parent, and we hold back the same amount again at the bottom so the
+  // picture stays optically centred in the viewport. Sideways it's the chevron
+  // gutters the wrapper declares via ``--nav-w`` (0 when there's nothing to
+  // page to, and on narrow viewports — see NAV_GUTTER).
+  const availH = `88dvh - 2 * ${CHROME_H}`;
+  const availW = "92vw - 2 * var(--nav-w, 0px)";
+
+  // Pin the displayed box to the file's known aspect ratio fitted into that
+  // space, so it's identical whether the cached thumbnail or the full-res
   // image is showing. Without this the box would track each bitmap's natural
   // size and visibly jump (small thumbnail -> larger full-res), and the morph
   // would aim at the wrong final size. ``width`` is the binding constraint of:
-  // the viewport width (92vw), the width at which height hits 88dvh, and the
-  // image's own width (so small images stay their natural size and never
-  // upscale into a blurry full-screen blob). ``height: auto`` derives the rest
-  // from the width/height attributes' aspect ratio.
+  // the available width, the width at which height fills the available
+  // height, and the image's own width (so small images stay their natural size
+  // and never upscale into a blurry full-screen blob). ``height: auto``
+  // derives the rest from the width/height attributes' aspect ratio.
   const ratioWH = file.width && file.height ? file.width / file.height : null;
   const sizeStyle =
     ratioWH && file.width
       ? {
-          width: `min(92vw, calc(${ratioWH.toFixed(4)} * 88dvh), ${String(file.width)}px)`,
+          width: `min(calc(${availW}), calc(${ratioWH.toFixed(4)} * (${availH})), ${String(file.width)}px)`,
           height: "auto",
         }
       : undefined;
@@ -386,8 +467,13 @@ function ImageContent({ file }: { file: MmFile }) {
       draggable={false}
       width={file.width ?? undefined}
       height={file.height ?? undefined}
-      style={{ viewTransitionName: MEDIA_VT_NAME, ...sizeStyle }}
-      className="block max-h-[88dvh] max-w-[92vw] select-none rounded-2xl object-contain shadow-2xl"
+      style={{
+        viewTransitionName: MEDIA_VT_NAME,
+        maxHeight: `calc(${availH})`,
+        maxWidth: `calc(${availW})`,
+        ...sizeStyle,
+      }}
+      className="block select-none rounded-2xl object-contain shadow-2xl"
     />
   );
 }
@@ -422,7 +508,7 @@ function MediaContent({
   if (!src) return <Spinner />;
   if (tag === "video") {
     return (
-      <div className="flex size-full items-center justify-center px-4 py-14 sm:px-6">
+      <div className="flex size-full items-center justify-center p-4 sm:p-6">
         <Video
           src={src}
           poster={file.thumbnail_url ?? undefined}
@@ -502,13 +588,9 @@ function PdfContent({ file, onDownload }: { file: MmFile; onDownload: () => void
   const { blobUrl, error } = useFileBytes(file, "blob", "application/pdf");
   if (error) return <FallbackContent file={file} onDownload={onDownload} message={error} />;
   if (!blobUrl) return <Spinner />;
-  return (
-    <iframe
-      src={blobUrl}
-      title={file.filename}
-      className="size-full bg-white px-2 py-14 sm:px-6"
-    />
-  );
+  // The panel already clips and rounds it, and the chrome is out of the way,
+  // so the PDF gets the whole surface.
+  return <iframe src={blobUrl} title={file.filename} className="size-full bg-white" />;
 }
 
 function TextContent({ file, onDownload }: { file: MmFile; onDownload: () => void }) {
@@ -527,12 +609,11 @@ function TextContent({ file, onDownload }: { file: MmFile; onDownload: () => voi
   if (text === null) return <Spinner />;
   const lang = languageForFile(file.filename);
   // One immersive, full-bleed reading surface — the code fills the viewer
-  // (no nested card/border), with the filename + actions floating over it.
-  // ``pt-16`` clears the top pills; ``bg-card`` keeps Shiki tokens readable
-  // in both themes (they follow the page's .dark class).
+  // (no nested card/border). ``bg-card`` keeps Shiki tokens readable in both
+  // themes (they follow the page's .dark class).
   return (
     <div className="size-full overflow-auto bg-card text-card-foreground">
-      <div className="min-h-full px-5 pb-10 pt-16 sm:px-8">
+      <div className="min-h-full px-5 pb-10 pt-6 sm:px-8">
         <CodeBlock code={text.replace(/\n$/, "")} lang={lang} bare />
       </div>
     </div>

--- a/frontend/src/components/MessageComposer.tsx
+++ b/frontend/src/components/MessageComposer.tsx
@@ -40,6 +40,7 @@ import {
 import { extractClipboardFiles } from "@/lib/clipboardFiles";
 import { isDesktop } from "@/lib/desktop";
 import { isHereToken } from "@/lib/mentions";
+import { quotedBodyText } from "@/lib/messageHelpers";
 import { cn } from "@/lib/utils";
 import type { MmChannel, MmChannelMember, MmChannelPost } from "@/lib/api";
 import type { PendingAutoMention } from "@/lib/autoMention";
@@ -1325,7 +1326,11 @@ export function MessageComposer(props: MessageComposerProps) {
                 <span className="text-muted-foreground">Replying to </span>
                 <span className="font-medium text-foreground/90">{replyPosterName(replyingTo)}</span>
                 <span className="text-muted-foreground"> · </span>
-                <span className="text-muted-foreground">{(replyingTo.message || "").trim() || "(empty message)"}</span>
+                {/* Attachment-only parents have no text — label them from
+                    the file count instead of reading as blank. */}
+                <span className="text-muted-foreground">
+                  {quotedBodyText(replyingTo.message || "", replyingTo.files?.length ?? 0)}
+                </span>
               </span>
               <button
                 type="button"

--- a/frontend/src/components/chat/MessageRow.tsx
+++ b/frontend/src/components/chat/MessageRow.tsx
@@ -9,6 +9,7 @@ import { createPortal } from "react-dom";
 
 import {
   ArrowTurnBackwardIcon,
+  Attachment01Icon as Paperclip,
   Clock01Icon,
   Copy01Icon,
   Delete02Icon,
@@ -69,7 +70,7 @@ import { burstEmojiAt, burstEmojiFrom } from "@/lib/emojiBurst";
 import { MENU_SURFACE } from "@/lib/menuSurface";
 import { extractUrls } from "@/lib/extractUrls";
 import { formatRelativeAgo, formatTimeOnly } from "@/lib/formatting";
-import { mentionHandle, posterName } from "@/lib/messageHelpers";
+import { mentionHandle, posterName, quotedBodyText } from "@/lib/messageHelpers";
 import { formatReactors } from "@/lib/reactionTooltip";
 import { toast } from "@/lib/toast";
 
@@ -707,6 +708,10 @@ function ParentQuoteBlock({
     preview.poster_display_name
     ?? preview.agent_id
     ?? (preview.human_id != null ? `User ${String(preview.human_id)}` : "Unknown");
+  // Attachment-only parents have no text to quote — the body slot gets a
+  // paperclip + "Attachment" label instead of reading as blank.
+  const attachmentCount = preview.attachment_count ?? 0;
+  const isAttachmentOnly = !preview.message_excerpt.trim() && attachmentCount > 0;
   return (
     <button
       type="button"
@@ -723,8 +728,13 @@ function ParentQuoteBlock({
         ) : (
           <>
             <span className="block truncate text-[12px] font-medium text-foreground/85">{authorName}</span>
-            <span className="block truncate text-[12px] text-muted-foreground">
-              {preview.message_excerpt || "(empty message)"}
+            <span className="flex min-w-0 items-center gap-1 text-[12px] text-muted-foreground">
+              {isAttachmentOnly && (
+                <Icon icon={Paperclip} className="size-2.5! shrink-0 opacity-70"/>
+              )}
+              <span className="min-w-0 truncate">
+                {quotedBodyText(preview.message_excerpt, attachmentCount)}
+              </span>
             </span>
           </>
         )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1112,6 +1112,10 @@ export interface MmPostParentPreview {
   poster_display_name: string | null;
   message_excerpt: string;
   status: MmPostStatus;
+  /** Uploaded files on the parent post. Lets the quote-block label an
+   *  attachment-only parent (which legitimately has no text) instead of
+   *  rendering it as blank. Absent on legacy payloads → treated as 0. */
+  attachment_count?: number;
 }
 
 export interface MmPostReaction {

--- a/frontend/src/lib/messageHelpers.test.ts
+++ b/frontend/src/lib/messageHelpers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { attachmentOnlyLabel, quotedBodyText } from "./messageHelpers";
+
+describe("attachmentOnlyLabel", () => {
+  it("returns null when there are no attachments", () => {
+    expect(attachmentOnlyLabel(0)).toBeNull();
+    expect(attachmentOnlyLabel(-1)).toBeNull();
+  });
+
+  it("matches the channel-list wording", () => {
+    expect(attachmentOnlyLabel(1)).toBe("Attachment");
+    expect(attachmentOnlyLabel(3)).toBe("3 attachments");
+  });
+});
+
+describe("quotedBodyText", () => {
+  it("prefers the message text", () => {
+    expect(quotedBodyText("hello", 2)).toBe("hello");
+  });
+
+  it("labels an attachment-only body instead of showing it as empty", () => {
+    expect(quotedBodyText("", 1)).toBe("Attachment");
+    expect(quotedBodyText("   ", 2)).toBe("2 attachments");
+  });
+
+  it("falls back to the placeholder only when there is truly nothing", () => {
+    expect(quotedBodyText("", 0)).toBe("(empty message)");
+  });
+});

--- a/frontend/src/lib/messageHelpers.ts
+++ b/frontend/src/lib/messageHelpers.ts
@@ -63,6 +63,24 @@ export function mentionLabel(member: MmChannelMember): string {
   );
 }
 
+/** One-line stand-in for a message body that has no text. A post is
+ *  allowed to be attachment-only (the composer enables Send as soon as
+ *  a file is ready), so anywhere a body is quoted at one-line size —
+ *  the reply strip in the composer, the quote-block above a reply — an
+ *  empty body means "attachments" far more often than it means
+ *  "nothing". Wording matches the channel-list previews.
+ *  Returns ``null`` when there is genuinely nothing to show. */
+export function attachmentOnlyLabel(count: number): string | null {
+  if (count <= 0) return null;
+  return count === 1 ? "Attachment" : `${String(count)} attachments`;
+}
+
+/** Text to render for a quoted message body: its own text when it has
+ *  any, else an attachment label, else a last-resort placeholder. */
+export function quotedBodyText(text: string, attachmentCount: number): string {
+  return text.trim() || attachmentOnlyLabel(attachmentCount) || "(empty message)";
+}
+
 /** Parse the in-progress ``@`` mention at the caret. Returns the
  *  selection range and the query string after the ``@``, or ``null``
  *  if the caret isn't currently sitting on a mention. */

--- a/frontend/src/pages/ChannelPage.tsx
+++ b/frontend/src/pages/ChannelPage.tsx
@@ -676,6 +676,7 @@ export default function ChannelPage() {
               // shortly anyway with the server's pre-truncated copy.
               message_excerpt: replyBefore.message,
               status: replyBefore.status,
+              attachment_count: replyBefore.files?.length ?? 0,
             }
           : null,
         // Optimistic posts skip the embedded preview — the server

--- a/tests/fastapi/test_human_mattermost.py
+++ b/tests/fastapi/test_human_mattermost.py
@@ -614,6 +614,85 @@ def test_human_delete_own_post_round_trip(test_client):
     assert all(p["post_id"] != post["post_id"] for p in listed["posts"])
 
 
+def test_human_delete_refreshes_channel_preview(test_client):
+    """Regression: deleting the newest post must rebuild the channel's
+    denormalised sidebar preview.
+
+    ``mm_channels.last_message_*`` is a snapshot written on publish, and the
+    channels-list endpoint serves it verbatim — so a delete that skipped the
+    recompute left the deleted message visible in the sidebar forever, even
+    across a full refetch. Deleting the last remaining post must clear the
+    preview outright."""
+    h1 = _register_human(test_client, "del-preview@test.com", display_name="Prue")
+    ch_id = _create_channel(test_client, h1["access_token"], "del-preview")["channel_id"]
+
+    def _preview() -> dict:
+        resp = test_client.get(
+            "/api/human/mm/channels", headers=_human_auth(h1["access_token"])
+        )
+        assert resp.status_code == 200, resp.text
+        return next(c for c in resp.json()["channels"] if c["channel_id"] == ch_id)
+
+    first = test_client.post(
+        f"/api/human/mm/channels/{ch_id}/posts",
+        json={"message": "the older one"},
+        headers=_human_auth(h1["access_token"]),
+    ).json()
+    second = test_client.post(
+        f"/api/human/mm/channels/{ch_id}/posts",
+        json={"message": "the newest one"},
+        headers=_human_auth(h1["access_token"]),
+    ).json()
+    assert _preview()["last_message_text"] == "the newest one"
+
+    r = test_client.delete(
+        f"/api/human/mm/posts/{second['post_id']}",
+        headers=_human_auth(h1["access_token"]),
+    )
+    assert r.status_code == 204, r.text
+
+    ch = _preview()
+    assert ch["last_message_text"] == "the older one"
+    assert ch["last_message_author_human_id"] == h1["user"]["id"]
+
+    # Deleting the last survivor empties the preview rather than stranding it.
+    r = test_client.delete(
+        f"/api/human/mm/posts/{first['post_id']}",
+        headers=_human_auth(h1["access_token"]),
+    )
+    assert r.status_code == 204, r.text
+
+    ch = _preview()
+    assert ch["last_message_text"] is None
+    assert ch["last_message_author_human_id"] is None
+    assert ch["last_message_author_display_name"] is None
+
+
+def test_human_edit_refreshes_channel_preview(test_client):
+    """Editing the newest post must rewrite the sidebar preview too —
+    same denormalised snapshot as the delete path above."""
+    h1 = _register_human(test_client, "edit-preview@test.com", display_name="Ed")
+    ch_id = _create_channel(test_client, h1["access_token"], "edit-preview")["channel_id"]
+    post = test_client.post(
+        f"/api/human/mm/channels/{ch_id}/posts",
+        json={"message": "typo verison"},
+        headers=_human_auth(h1["access_token"]),
+    ).json()
+
+    r = test_client.patch(
+        f"/api/human/mm/posts/{post['post_id']}",
+        json={"message": "typo version"},
+        headers=_human_auth(h1["access_token"]),
+    )
+    assert r.status_code == 200, r.text
+
+    resp = test_client.get(
+        "/api/human/mm/channels", headers=_human_auth(h1["access_token"])
+    ).json()
+    ch = next(c for c in resp["channels"] if c["channel_id"] == ch_id)
+    assert ch["last_message_text"] == "typo version"
+
+
 def test_human_delete_other_user_post_forbidden(test_client):
     """A non-author, non-creator member cannot delete someone else's post."""
     h1 = _register_human(test_client, "del-owner@test.com")

--- a/tests/fastapi/test_mattermost_files.py
+++ b/tests/fastapi/test_mattermost_files.py
@@ -359,6 +359,57 @@ def test_post_files_appear_in_list(test_client):
     assert with_files[0]["files"][0]["download_url"] is not None
 
 
+def test_parent_preview_counts_attachments(test_client):
+    """An attachment-only parent carries ``attachment_count`` in the quote
+    payload. A post with files needs no text, so without the count the
+    client can't tell "attachment-only" from "genuinely blank" and used to
+    render the quote-block as "(empty message)"."""
+    agent = _create_owned_agent(test_client)
+    cid = _default_channel_id(test_client, agent)
+    f1 = _request_upload(test_client, agent, cid, filename="a.png")
+    _confirm_upload(test_client, agent, f1["file_id"])
+    f2 = _request_upload(test_client, agent, cid, filename="b.png")
+    _confirm_upload(test_client, agent, f2["file_id"])
+
+    parent = test_client.post(
+        f"/api/agentic/mm/channels/{cid}/posts",
+        json={"message": "", "file_ids": [f1["file_id"], f2["file_id"]]},
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+    assert parent.status_code == 200, parent.text
+    parent_id = parent.json()["post_id"]
+
+    r = test_client.post(
+        f"/api/agentic/mm/channels/{cid}/posts",
+        json={"message": "nice shots", "parent_post_id": parent_id},
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+    assert r.status_code == 200, r.text
+    preview = r.json()["parent_preview"]
+    assert preview["message_excerpt"] == ""
+    assert preview["attachment_count"] == 2
+
+
+def test_parent_preview_attachment_count_zero_for_text_post(test_client):
+    """Text-only parents report a zero count, so the quote-block keeps
+    rendering the excerpt and never shows an attachment label."""
+    agent = _create_owned_agent(test_client)
+    cid = _default_channel_id(test_client, agent)
+    parent = test_client.post(
+        f"/api/agentic/mm/channels/{cid}/posts",
+        json={"message": "just words"},
+        headers=_write_headers(test_client, agent["api_key"]),
+    ).json()
+
+    r = test_client.post(
+        f"/api/agentic/mm/channels/{cid}/posts",
+        json={"message": "reply", "parent_post_id": parent["post_id"]},
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["parent_preview"]["attachment_count"] == 0
+
+
 def test_post_with_too_many_files_rejected(test_client, monkeypatch):
     """Caps from MM_FILES_MAX_PER_POST are enforced at post-create time."""
     monkeypatch.setenv("MM_FILES_MAX_PER_POST", "1")

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -283,6 +283,23 @@ const jsonLd = {
         // first value, so the strip above the hero stays the page ground. Every
         // callback re-measures instead, and a zero-height rect (layout not
         // ready) says nothing at all rather than guessing wrong.
+        //
+        // A CLASSIC SCROLLBAR MUST NOT GET THE DARK CANVAS.
+        //
+        // [data-hero-top] paints body, and body's background is the document
+        // canvas (html has none), so it reaches the scrollbar gutter as well -
+        // a strip main's own ground cannot cover, because main stops at
+        // clientWidth. With overlay scrollbars there is no gutter and nothing
+        // shows; with a classic one (macOS "Show scroll bars: Always", Windows,
+        // Safari's translucent track) the dark canvas reads as a black column
+        // down the right edge for exactly as long as the hero holds the top.
+        //
+        // Phrased as "is there a gutter", not "is this iOS": the attribute
+        // exists only for iOS Safari's chrome band, and iOS is always overlay,
+        // so a measurement that comes back 0 - or NaN, on an engine that
+        // surprises us - keeps the iOS behaviour rather than dropping it.
+        const gutter = () => window.innerWidth - document.documentElement.clientWidth;
+
         const sync = () => {
           const rect = anchor.getBoundingClientRect();
           if (rect.height === 0) return;
@@ -291,7 +308,7 @@ const jsonLd = {
           // Drives the canvas background too - see the [data-hero-top] note in
           // global.css. An attribute rather than an inline style: the
           // production CSP has no 'unsafe-inline' in style-src.
-          document.documentElement.toggleAttribute("data-hero-top", holdsTop);
+          document.documentElement.toggleAttribute("data-hero-top", holdsTop && !(gutter() >= 1));
         };
 
         requestAnimationFrame(sync);


### PR DESCRIPTION
This pull request improves the handling and display of attachment-only messages in chat, ensuring that messages with only attachments (and no text) are clearly labeled throughout the mobile and web UIs. It also ensures that channel previews update correctly when posts are edited or deleted, and refines the attachment viewer's UI so that controls never obscure the content.

**Attachment-only message support and display:**

* Added a utility function `quotedBodyText` (and helper `attachmentOnlyLabel`) in `formatting.ts` to generate a user-friendly label (e.g., "Attachment" or "2 attachments") for messages that have no text but do have attachments, ensuring quoted messages and reply banners are never blank or misleading.
* Updated message quoting logic in both the chat screen (`chats/[channelId].tsx`) and message bubble (`message-bubble.tsx`) to use `quotedBodyText`, and passed the new `attachment_count` field through the relevant data structures and UI components. ([apps/mobile/src/app/(tabs)/chats/[channelId].tsxR68](diffhunk://#diff-458f6e2a33f956d62fb00bdb44b5e01e944a51a6aa5fcd7aa9d23a3df043ffffR68), [apps/mobile/src/app/(tabs)/chats/[channelId].tsxR663](diffhunk://#diff-458f6e2a33f956d62fb00bdb44b5e01e944a51a6aa5fcd7aa9d23a3df043ffffR663), [apps/mobile/src/app/(tabs)/chats/[channelId].tsxL961-R965](diffhunk://#diff-458f6e2a33f956d62fb00bdb44b5e01e944a51a6aa5fcd7aa9d23a3df043ffffL961-R965), [[1]](diffhunk://#diff-94fec5987f4f336d3741c6dc0a3e476a6b2b5dfab7f4e91e7397ff6b9782f64fR32) [[2]](diffhunk://#diff-94fec5987f4f336d3741c6dc0a3e476a6b2b5dfab7f4e91e7397ff6b9782f64fL406-R411) [[3]](diffhunk://#diff-94fec5987f4f336d3741c6dc0a3e476a6b2b5dfab7f4e91e7397ff6b9782f64fL442-R447) [[4]](diffhunk://#diff-822363b09fe6748492cf884b6eb4493af09c5bcf587b958c31d06656c8c3f0acL257-R257) [[5]](diffhunk://#diff-ee668e6733d9513bb5b4013a0250120650d6a7b108e6d5a1f237c83028c2f209R369-R372)

**Backend support for attachment counts:**

* The backend now computes and returns `attachment_count` in `MmPostParentPreview` and its API, so the client can distinguish between truly empty and attachment-only parent messages. [[1]](diffhunk://#diff-7912573bf6bf2d7b41b460c21519cecc71767129761333d78db57104275ae2c4R349-R361) [[2]](diffhunk://#diff-03aea7bfa15f2daa73265fa0e1029abd99cf5e0977dbe52a03fd1eedc1c43e5cR1784-R1802)

**Channel preview consistency:**

* When a post is edited or deleted, the denormalized channel preview is recomputed to reflect the latest message, preventing stale or incorrect previews in the chat list. [[1]](diffhunk://#diff-91daf25edcff5b7097eaf9805e47665ba0870badccd62de73bf58a909a11280dR2661-R2664) [[2]](diffhunk://#diff-91daf25edcff5b7097eaf9805e47665ba0870badccd62de73bf58a909a11280dR2742-R2748)
* The mobile app now invalidates the channel list on `post.deleted` events to fetch updated previews from the server.

**Attachment viewer UI improvements (web):**

* Refactored the attachment viewer so that the control bar (chrome) is always outside the media area, never covering the content, and added idle detection to fade controls when the user is just viewing. Navigation chevrons adapt to screen size to avoid shrinking images unnecessarily. [[1]](diffhunk://#diff-35666d40e1c33460484b107139e591cb5c933eafeb0aff99d286f783cb7609eeR35-R48) [[2]](diffhunk://#diff-35666d40e1c33460484b107139e591cb5c933eafeb0aff99d286f783cb7609eeL44-R68) [[3]](diffhunk://#diff-35666d40e1c33460484b107139e591cb5c933eafeb0aff99d286f783cb7609eeR157-R209) [[4]](diffhunk://#diff-35666d40e1c33460484b107139e591cb5c933eafeb0aff99d286f783cb7609eeL197-R282) [[5]](diffhunk://#diff-35666d40e1c33460484b107139e591cb5c933eafeb0aff99d286f783cb7609eeL232-R291)