### PR TITLE
Fix app url for staging

### DIFF
--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -100,8 +100,8 @@ jobs:
         #
         # PUBLIC_APP_URL is the staging APP's URL, not the staging SITE's: the
         # marketing site on preview.freeclaws.ai must link to the freeclaws
-        # deployment of the app. It is the apex today and becomes
-        # app.freeclaws.ai at the Phase 6 cutover - flip this line then.
+        # deployment of the app. Both targets now point at app.* - the app moved
+        # off the apex, and the apex is becoming the marketing site.
         run: |
           if [ "${{ github.ref_name }}" = "prod" ]; then
             {
@@ -113,7 +113,7 @@ jobs:
             {
               echo "env=staging"
               echo "site=https://preview.freeclaws.ai"
-              echo "app=https://freeclaws.ai"
+              echo "app=https://app.freeclaws.ai"
             } >> "$GITHUB_OUTPUT"
           fi
 

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "preview": "astro preview",
     "check": "astro check",
     "verify:legal": "node scripts/verify-legal-parity.mjs",
-    "deploy:staging": "SITE_URL=https://preview.freeclaws.ai PUBLIC_APP_URL=https://freeclaws.ai bun run build && wrangler deploy --env staging",
+    "deploy:staging": "SITE_URL=https://preview.freeclaws.ai PUBLIC_APP_URL=https://app.freeclaws.ai bun run build && wrangler deploy --env staging",
     "deploy:production": "SITE_URL=https://preview.clawbits.ai PUBLIC_APP_URL=https://app.clawbits.ai bun run build && wrangler deploy --env production",
     "verify:links": "node scripts/verify-links.mjs",
     "verify:no-inline-styles": "node scripts/verify-no-inline-styles.mjs",


### PR DESCRIPTION
This pull request updates deployment configurations to reflect that the application has moved off the apex domain to a subdomain (`app.*`), and the apex is now dedicated to the marketing site. The main changes ensure that all references to the app's URL in both workflow and deployment scripts point to the correct subdomain.

**Deployment and workflow configuration updates:**

* Updated documentation in `.github/workflows/web.yaml` to clarify that both staging and production app deployments now use the `app.*` subdomain, as the apex is reserved for the marketing site.
* Changed the staging app URL from `https://freeclaws.ai` to `https://app.freeclaws.ai` in the GitHub Actions workflow output for staging deployments.
* Updated the `deploy:staging` script in `web/package.json` to use the new `PUBLIC_APP_URL=https://app.freeclaws.ai` for staging builds.