### PR TITLE
Fix git path issue

### DIFF
--- a/clawbits/datastructures/git_models.py
+++ b/clawbits/datastructures/git_models.py
@@ -18,9 +18,19 @@ class CreateRepoRequest(BaseModel):
     org_id: str | None = Field(default=None, description="Organization ID (defaults to primary owner org)")
 
 
+# A path segment: chars from [A-Za-z0-9._-] with at least one non-dot char,
+# so "." and ".." never match. Anchored segments joined by "/" also exclude
+# absolute paths, empty components, backslashes, and whitespace.
+_PATH_SEGMENT = r"[A-Za-z0-9._-]*[A-Za-z0-9_-][A-Za-z0-9._-]*"
+
+
 class FileChange(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
-    path: str = Field(min_length=1, max_length=512, description="File path relative to repo root")
+    path: str = Field(
+        min_length=1, max_length=512,
+        pattern=rf"^{_PATH_SEGMENT}(/{_PATH_SEGMENT})*$",
+        description="File path relative to repo root (segments of letters, digits, '.', '_', '-'; no absolute paths, no '.' or '..' segments)",
+    )
     content: str | None = Field(default=None, description="File content (required for create/update)")
     action: Literal["create", "update", "delete"] = Field(description="Action to perform")
 

--- a/clawbits/fastapi/git_endpoints.py
+++ b/clawbits/fastapi/git_endpoints.py
@@ -304,12 +304,15 @@ class GitEndpoints:
                         )
 
             files = [{"path": f.path, "content": f.content, "action": f.action} for f in body.files]
-            result = repo_manager.create_commit(
-                base_path, repo["org_id"], repo_name,
-                body.message, files,
-                author_name=agent_id, author_email=author_email,
-                branch=body.branch,
-            )
+            try:
+                result = repo_manager.create_commit(
+                    base_path, repo["org_id"], repo_name,
+                    body.message, files,
+                    author_name=agent_id, author_email=author_email,
+                    branch=body.branch,
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=f"Invalid file path: {e}")
             if result is None:
                 raise HTTPException(status_code=500, detail="Failed to create commit")
 

--- a/clawbits/git/repo_manager.py
+++ b/clawbits/git/repo_manager.py
@@ -3,7 +3,8 @@
 Repos are stored on disk at ``{base_path}/{org_id}/{repo_name}``.
 
 Environment variable:
-    GIT_REPOS_BASE_PATH  – root directory for all repos (default: ./git_repos)
+    GIT_REPOS_BASE_PATH  – root directory for all repos
+                           (default: ~/.local/share/clawbits/git_repos)
 """
 import logging
 import os
@@ -14,7 +15,13 @@ from clawbits.domain import SYSTEM_EMAIL
 
 logger = logging.getLogger(__name__)
 
-GIT_REPOS_BASE_PATH = os.getenv("GIT_REPOS_BASE_PATH", os.path.join(os.getcwd(), "git_repos"))
+# The default must live outside the application directory: repo contents are
+# agent-supplied, and a repo root under the source tree turns any containment
+# bug into writes next to importable code.
+GIT_REPOS_BASE_PATH = os.getenv(
+    "GIT_REPOS_BASE_PATH",
+    os.path.join(os.path.expanduser("~"), ".local", "share", "clawbits", "git_repos"),
+)
 
 
 def _run_git(args: list[str], cwd: str, env: dict | None = None) -> subprocess.CompletedProcess:
@@ -36,6 +43,62 @@ def _run_git(args: list[str], cwd: str, env: dict | None = None) -> subprocess.C
 def repo_path(base_path: str, org_id: str, repo_name: str) -> str:
     """Return the on-disk path for a repository."""
     return os.path.join(base_path, org_id, repo_name)
+
+
+def _validate_rel_path(rel_path: str) -> list[str]:
+    """Lexically validate a repo-relative path and return its components.
+
+    Raises ValueError if ``rel_path`` is absolute or has an empty / ``.`` /
+    ``..`` / ``.git`` component. ``.git`` is rejected because a write there
+    (hooks, config) executes on the next git invocation.
+    """
+    if os.path.isabs(rel_path) or rel_path.startswith(("/", "\\")):
+        raise ValueError(f"absolute path not allowed: {rel_path!r}")
+    parts = rel_path.replace("\\", "/").split("/")
+    if any(part in ("", ".", "..") or part.lower() == ".git" for part in parts):
+        raise ValueError(f"invalid path component in: {rel_path!r}")
+    return parts
+
+
+def _write_repo_file(rpath: str, parts: list[str], content: str) -> None:
+    """Write a file at ``parts`` under ``rpath`` without following any symlink.
+
+    Walks component-by-component with ``dir_fd`` + ``O_NOFOLLOW``, so a symlink
+    in the working tree (including one materialized by checkout, or one that
+    appears mid-walk) can never redirect the write outside the repository or
+    into ``.git``. Raises ValueError if any component is a symlink or not a
+    plain directory / regular file.
+    """
+    dir_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    fd = os.open(rpath, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        for part in parts[:-1]:
+            try:
+                try:
+                    nfd = os.open(part, dir_flags, dir_fd=fd)
+                except FileNotFoundError:
+                    try:
+                        os.mkdir(part, dir_fd=fd)
+                    except FileExistsError:
+                        pass
+                    nfd = os.open(part, dir_flags, dir_fd=fd)
+            except OSError as e:
+                raise ValueError(f"unsafe path component {part!r} in {'/'.join(parts)!r}") from e
+            os.close(fd)
+            fd = nfd
+        try:
+            ffd = os.open(
+                parts[-1],
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW | os.O_CLOEXEC,
+                0o644,
+                dir_fd=fd,
+            )
+        except OSError as e:
+            raise ValueError(f"unsafe path {'/'.join(parts)!r}") from e
+        with os.fdopen(ffd, "wb") as fh:
+            fh.write(content.encode("utf-8"))
+    finally:
+        os.close(fd)
 
 
 def init_repo(
@@ -207,6 +270,10 @@ def create_commit(
     if not os.path.isdir(rpath):
         return None
 
+    # Validate every path before mutating anything: paths are agent-supplied,
+    # and the write below happens before git sees them.
+    parts_by_path = {f["path"]: _validate_rel_path(f["path"]) for f in files}
+
     env = {
         "GIT_AUTHOR_NAME": author_name,
         "GIT_AUTHOR_EMAIL": author_email,
@@ -214,21 +281,22 @@ def create_commit(
         "GIT_COMMITTER_EMAIL": author_email,
     }
 
-    # Checkout the branch
-    _run_git(["checkout", branch], cwd=rpath, env=env)
+    # Checkout the branch; on failure abort rather than commit elsewhere.
+    if _run_git(["checkout", branch], cwd=rpath, env=env).returncode != 0:
+        return None
 
-    # Apply file changes
+    # Apply file changes. Physical (symlink) checks happen inside
+    # _write_repo_file, necessarily after checkout has settled the tree.
     for f in files:
-        file_path = os.path.join(rpath, f["path"])
         action = f["action"]
 
         if action in ("create", "update"):
-            # Ensure parent directory exists
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            Path(file_path).write_text(f.get("content", ""), encoding="utf-8")
-            _run_git(["add", f["path"]], cwd=rpath)
+            _write_repo_file(rpath, parts_by_path[f["path"]], f.get("content") or "")
+            if _run_git(["add", "--", f["path"]], cwd=rpath).returncode != 0:
+                return None
         elif action == "delete":
-            _run_git(["rm", "-f", f["path"]], cwd=rpath)
+            if _run_git(["rm", "-f", "--", f["path"]], cwd=rpath).returncode != 0:
+                return None
 
     # Commit
     result = _run_git(["commit", "-m", message, "--allow-empty"], cwd=rpath, env=env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ indent-style = "space"
 [tool.pytest.ini_options]
 pythonpath = ["."]
 addopts = "-ra"
-testpaths = ["tests/avatars", "tests/fastapi", "tests/link_preview", "tests/lobstertalk", "tests/poc", "tests/test_bot_names.py", "reef/tests"]
+testpaths = ["tests/avatars", "tests/fastapi", "tests/git", "tests/link_preview", "tests/lobstertalk", "tests/poc", "tests/test_bot_names.py", "reef/tests"]
 norecursedirs = ["frontend", "node_modules"]

--- a/tests/fastapi/test_git_repos.py
+++ b/tests/fastapi/test_git_repos.py
@@ -1,4 +1,5 @@
 """Tests for Git repository API endpoints."""
+import os
 import tempfile
 
 import pytest
@@ -383,4 +384,102 @@ def test_repo_not_found(test_client):
         headers=_auth(agent["api_key"]),
     )
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests: Commit path containment
+# ---------------------------------------------------------------------------
+
+def test_commit_traversal_paths_rejected(test_client, _git_base_path):
+    """Traversal, absolute, and dot-segment paths are rejected before any write."""
+    _register_human(test_client, "traversal@test.com")
+    agent = _create_agent(test_client)
+    _add_owner(test_client, agent, "traversal@test.com")
+
+    test_client.post(
+        f"/api/agentic/agents/{agent['agent_id']}/repos",
+        json={"name": "safe-repo"},
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+
+    bad_paths = [
+        "../../evil.txt",       # traversal out of the repo
+        "/etc/cron.d/evil",     # absolute: os.path.join would discard the base
+        "a/../../../b.txt",     # traversal mid-path
+        "./x.txt",              # '.' segment
+        "a//b.txt",             # empty segment
+        "a\\..\\b.txt",         # backslash separators
+        "evil .txt",            # whitespace outside the allowed charset
+    ]
+    for bad in bad_paths:
+        for file_change in (
+            {"path": bad, "content": "pwn", "action": "create"},
+            {"path": bad, "action": "delete"},
+        ):
+            r = test_client.post(
+                f"/api/agentic/agents/{agent['agent_id']}/repos/safe-repo/commits",
+                json={"message": "x", "files": [file_change]},
+                headers=_write_headers(test_client, agent["api_key"]),
+            )
+            assert r.status_code == 422, f"{bad!r} ({file_change['action']}): {r.status_code} {r.text}"
+
+    # '../../evil.txt' resolves to the base directory root; prove nothing landed there.
+    assert not os.path.exists(os.path.join(_git_base_path, "evil.txt"))
+
+
+def test_commit_git_dir_write_rejected(test_client):
+    """Writes into .git/ (hooks, config) are refused by the containment layer."""
+    _register_human(test_client, "gitdir@test.com")
+    agent = _create_agent(test_client)
+    _add_owner(test_client, agent, "gitdir@test.com")
+
+    test_client.post(
+        f"/api/agentic/agents/{agent['agent_id']}/repos",
+        json={"name": "hook-repo"},
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+
+    r = test_client.post(
+        f"/api/agentic/agents/{agent['agent_id']}/repos/hook-repo/commits",
+        json={
+            "message": "x",
+            "files": [{"path": ".git/hooks/post-checkout", "content": "#!/bin/sh\n", "action": "create"}],
+        },
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+    assert r.status_code == 400, r.text
+    assert "path" in r.json()["detail"].lower()
+
+
+def test_commit_dotfiles_and_nested_paths_ok(test_client):
+    """Legitimate dotfiles and nested paths still commit fine."""
+    _register_human(test_client, "dotfile@test.com")
+    agent = _create_agent(test_client)
+    _add_owner(test_client, agent, "dotfile@test.com")
+
+    test_client.post(
+        f"/api/agentic/agents/{agent['agent_id']}/repos",
+        json={"name": "dot-repo"},
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+
+    r = test_client.post(
+        f"/api/agentic/agents/{agent['agent_id']}/repos/dot-repo/commits",
+        json={
+            "message": "Add dotfile and nested file",
+            "files": [
+                {"path": ".gitignore", "content": "*.pyc\n", "action": "create"},
+                {"path": "docs/notes/readme.md", "content": "hi\n", "action": "create"},
+            ],
+        },
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+    assert r.status_code == 200, r.text
+
+    r = test_client.get(
+        f"/api/agentic/agents/{agent['agent_id']}/repos/dot-repo/blob/docs/notes/readme.md",
+        headers=_auth(agent["api_key"]),
+    )
+    assert r.status_code == 200
+    assert r.json()["content"] == "hi\n"
 

--- a/tests/git/test_repo_manager.py
+++ b/tests/git/test_repo_manager.py
@@ -1,0 +1,138 @@
+"""Containment tests for repo_manager — the layer below the API models.
+
+The pydantic pattern on ``FileChange.path`` rejects most hostile paths at the
+endpoint; these tests pin the defense-in-depth check inside ``create_commit``
+so a future caller (or model change) cannot reintroduce the traversal.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from clawbits.git import repo_manager
+
+
+def _commit_one(base_path, path, action="create"):
+    return repo_manager.create_commit(
+        str(base_path), "org1", "r1", "msg",
+        [{"path": path, "content": "x", "action": action}],
+        author_name="agent-1", author_email="agent-1@test",
+    )
+
+
+def test_rejects_escaping_paths(tmp_path):
+    repo_manager.init_repo(str(tmp_path), "org1", "r1")
+
+    bad_paths = [
+        "../../evil.txt",              # traversal out of the repo
+        "../sibling-repo/f.txt",       # traversal into another repo
+        "/etc/cron.d/evil",            # absolute: os.path.join discards the base
+        "a/../../../b.txt",            # traversal mid-path
+        "./x.txt",                     # '.' component
+        "a//b.txt",                    # empty component
+        "a\\..\\b.txt",                # backslash separators
+        ".git/hooks/post-checkout",    # git-dir write executes on next checkout
+        ".git/config",
+    ]
+    for bad in bad_paths:
+        with pytest.raises(ValueError):
+            _commit_one(tmp_path, bad)
+        with pytest.raises(ValueError):
+            _commit_one(tmp_path, bad, action="delete")
+
+    assert not (tmp_path / "evil.txt").exists()
+    assert not (tmp_path / "b.txt").exists()
+
+
+def test_rejects_symlink_escape(tmp_path):
+    base = tmp_path / "base"
+    rpath = repo_manager.init_repo(str(base), "org1", "r1")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.symlink(outside, os.path.join(rpath, "link"))
+
+    with pytest.raises(ValueError):
+        _commit_one(base, "link/evil.txt")
+    assert not (outside / "evil.txt").exists()
+
+
+def test_rejects_symlink_into_git_dir(tmp_path):
+    """A symlink whose target is *inside* the repo (.git) must also be refused."""
+    rpath = repo_manager.init_repo(str(tmp_path), "org1", "r1")
+    os.symlink(os.path.join(rpath, ".git"), os.path.join(rpath, "metadata"))
+
+    with pytest.raises(ValueError):
+        _commit_one(tmp_path, "metadata/hooks/post-checkout")
+    assert not (Path(rpath) / ".git" / "hooks" / "post-checkout").exists()
+
+
+def test_rejects_symlink_planted_via_branch_checkout(tmp_path):
+    """Checkout runs before writes; a symlink restored by it must not be followed."""
+    base = tmp_path / "base"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    rpath = repo_manager.init_repo(str(base), "org1", "r1")
+
+    # Plant a committed symlink on a side branch, out-of-band of the API.
+    env = {
+        "GIT_AUTHOR_NAME": "a", "GIT_AUTHOR_EMAIL": "a@test",
+        "GIT_COMMITTER_NAME": "a", "GIT_COMMITTER_EMAIL": "a@test",
+    }
+    assert repo_manager._run_git(["checkout", "-b", "evil"], cwd=rpath).returncode == 0
+    os.symlink(outside, os.path.join(rpath, "link"))
+    assert repo_manager._run_git(["add", "link"], cwd=rpath).returncode == 0
+    assert repo_manager._run_git(["commit", "-m", "plant"], cwd=rpath, env=env).returncode == 0
+    assert repo_manager._run_git(["checkout", "main"], cwd=rpath).returncode == 0
+
+    with pytest.raises(ValueError):
+        repo_manager.create_commit(
+            str(base), "org1", "r1", "msg",
+            [{"path": "link/x.txt", "content": "x", "action": "create"}],
+            author_name="agent-1", author_email="agent-1@test",
+            branch="evil",
+        )
+    assert not (outside / "x.txt").exists()
+
+
+def test_unknown_branch_fails_without_committing(tmp_path):
+    repo_manager.init_repo(str(tmp_path), "org1", "r1")
+
+    result = _commit_one(tmp_path, "f.txt")  # implicit branch="main" works
+    assert result is not None
+
+    before = repo_manager.count_commits(str(tmp_path), "org1", "r1")
+    result = repo_manager.create_commit(
+        str(tmp_path), "org1", "r1", "msg",
+        [{"path": "g.txt", "content": "x", "action": "create"}],
+        author_name="agent-1", author_email="agent-1@test",
+        branch="does-not-exist",
+    )
+    assert result is None
+    assert repo_manager.count_commits(str(tmp_path), "org1", "r1") == before
+
+
+def test_failed_git_action_does_not_fake_success(tmp_path):
+    """Deleting a nonexistent file must fail, not produce an empty 'success' commit."""
+    repo_manager.init_repo(str(tmp_path), "org1", "r1")
+
+    before = repo_manager.count_commits(str(tmp_path), "org1", "r1")
+    result = _commit_one(tmp_path, "nonexistent.txt", action="delete")
+    assert result is None
+    assert repo_manager.count_commits(str(tmp_path), "org1", "r1") == before
+
+
+def test_accepts_contained_paths(tmp_path):
+    repo_manager.init_repo(str(tmp_path), "org1", "r1")
+
+    commit = repo_manager.create_commit(
+        str(tmp_path), "org1", "r1", "msg",
+        [
+            {"path": ".gitignore", "content": "*.pyc\n", "action": "create"},
+            {"path": "docs/notes/readme.md", "content": "hi\n", "action": "create"},
+        ],
+        author_name="agent-1", author_email="agent-1@test",
+    )
+    assert commit is not None
+    rpath = Path(repo_manager.repo_path(str(tmp_path), "org1", "r1"))
+    assert (rpath / ".gitignore").read_text() == "*.pyc\n"
+    assert (rpath / "docs" / "notes" / "readme.md").read_text() == "hi\n"


### PR DESCRIPTION
## What and why

Agent-supplied file paths in `create_commit` were joined onto the repo
directory without validation, so paths with absolute or `..` components (or
paths passing through a symlink in the working tree) could resolve outside the
repository root; git subprocess failures were also ignored, so a commit could
report success without doing what was asked. Paths are now validated at the
model (`FileChange.path` pattern) and again in `repo_manager`, writes go
through a symlink-free `dir_fd`/`O_NOFOLLOW` walk after checkout, checkout /
add / rm return codes abort the commit on failure, and the default
`GIT_REPOS_BASE_PATH` moved out of the application working directory to
`~/.local/share/clawbits/git_repos`.

## How to verify
uv run pytest tests/git tests/fastapi/test_git_repos.py


All 22 pass (7 new unit tests for the containment layer, 3 new endpoint
tests). Or exercise the endpoint directly: `POST
/api/agentic/agents/{agent_id}/repos/{repo}/commits` with a file path like
`../../x.txt` or `/etc/x` now returns 422, `.git/hooks/x` returns 400, and
`.gitignore` / `docs/notes/readme.md` still commit fine.

## Notes

- Two-layer design on purpose: the pydantic pattern rejects malformed paths at
  the API boundary (422), while `repo_manager` independently rejects anything
  escaping the repo — including symlinks materialized by the branch checkout
  itself, which is why the physical check runs per-write *after* checkout
  rather than up front. The `O_NOFOLLOW` walk makes check and write one
  operation, so there is no window between them.
- Behaviour changes: committing to a nonexistent branch now fails instead of
  silently committing to the currently checked-out branch; a failed
  `git add`/`git rm` (e.g. deleting a file that doesn't exist) now fails
  instead of producing an empty commit that claims success.
- `tests/git` added to `testpaths` in pyproject.toml — it's an allowlist, and
  new test directories are otherwise silently uncollected.
- Existing deployments that relied on the old `./git_repos` default need
  `GIT_REPOS_BASE_PATH` set (per `docs/protocol/SKILLS_LIBRARY_PLAN.md` the
  subsystem isn't provisioned in production yet, so this should affect no one).
- Read-side endpoints (`read_blob`, `list_tree`) are unchanged: they resolve
  `ref:path` inside git's object store, not the filesystem.

---

- [ ] Commits signed off (`git commit -s`) — see [CONTRIBUTING](CONTRIBUTING.md#sign-off-dco)
- [ ] Conventional commit subject (`fix:` — suggested: `fix: validate file paths in agent repo commits`)
- [x] Tests added or updated for behaviour changes
- [ ] `db_schema.md` regenerated if a model changed, and a migration added — n/a, no model/schema change