### PR TITLE
Fix git regex issue

### DIFF
--- a/clawbits/datastructures/git_models.py
+++ b/clawbits/datastructures/git_models.py
@@ -35,11 +35,21 @@ class FileChange(BaseModel):
     action: Literal["create", "update", "delete"] = Field(description="Action to perform")
 
 
+# A ref must start with an alphanumeric/underscore so it can never be parsed as
+# a git *option* — refs are passed to git as lone argv tokens, and a leading "-"
+# turns one into a flag (see _validate_ref in clawbits/git/repo_manager.py, which
+# repeats this check below the API for callers that bypass the model).
+_REF_PATTERN = r"^[A-Za-z0-9_][A-Za-z0-9._/-]*$"
+
+
 class CreateCommitRequest(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
     message: str = Field(min_length=1, max_length=1000, description="Commit message")
     files: list[FileChange] = Field(min_length=1, max_length=100, description="File changes to commit")
-    branch: str = Field(default="main", description="Branch to commit to")
+    branch: str = Field(
+        default="main", max_length=255, pattern=_REF_PATTERN,
+        description="Branch to commit to (ref name; must not start with '-')",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/clawbits/fastapi/git_endpoints.py
+++ b/clawbits/fastapi/git_endpoints.py
@@ -190,6 +190,8 @@ class GitEndpoints:
             )
         except HTTPException:
             raise
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             logger.exception(f"Error listing commits: {e}")
             raise HTTPException(status_code=500, detail=str(e))
@@ -226,6 +228,8 @@ class GitEndpoints:
             )
         except HTTPException:
             raise
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             logger.exception(f"Error listing tree: {e}")
             raise HTTPException(status_code=500, detail=str(e))
@@ -264,6 +268,8 @@ class GitEndpoints:
             )
         except HTTPException:
             raise
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             logger.exception(f"Error reading blob: {e}")
             raise HTTPException(status_code=500, detail=str(e))
@@ -312,7 +318,8 @@ class GitEndpoints:
                     branch=body.branch,
                 )
             except ValueError as e:
-                raise HTTPException(status_code=400, detail=f"Invalid file path: {e}")
+                # Covers both the per-file path check and the branch ref check.
+                raise HTTPException(status_code=400, detail=f"Invalid request: {e}")
             if result is None:
                 raise HTTPException(status_code=500, detail="Failed to create commit")
 

--- a/clawbits/git/repo_manager.py
+++ b/clawbits/git/repo_manager.py
@@ -8,6 +8,7 @@ Environment variable:
 """
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -58,6 +59,37 @@ def _validate_rel_path(rel_path: str) -> list[str]:
     if any(part in ("", ".", "..") or part.lower() == ".git" for part in parts):
         raise ValueError(f"invalid path component in: {rel_path!r}")
     return parts
+
+
+# Refs reach this module straight from query params. A ref is passed to git as
+# its own argv token, so one starting with "-" is parsed as an *option*, not a
+# revision — and several of the commands below accept ``--output=<path>``, which
+# redirects their output to an arbitrary file (``git log``/``git show`` write the
+# commit subject or diff there; ``rev-list`` truncates the file to zero even
+# though it then errors). The charset below is strictly tighter than
+# ``git check-ref-format``: it admits branch names, tag names, ``refs/...``
+# paths and SHAs, and excludes every character that could start an option or
+# reach git's revision grammar (``^ ~ : ? * [ \ @{`` and whitespace).
+_REF_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._/-]*$", re.ASCII)
+
+
+def _validate_ref(ref: str) -> str:
+    """Validate a branch / tag / commit-ish before it becomes a git argv token.
+
+    Raises ValueError unless ``ref`` is a plain ref name or SHA. The leading
+    character is constrained to alphanumeric/underscore, which is what rejects
+    the option-injection case (a leading ``-``); the rest bars git's range and
+    reflog syntax so a ref can only ever name one revision.
+    """
+    if not ref:
+        raise ValueError("ref must not be empty")
+    if len(ref) > 255:
+        raise ValueError(f"ref too long ({len(ref)} chars, max 255)")
+    if not _REF_RE.match(ref):
+        raise ValueError(f"invalid ref: {ref!r}")
+    if ".." in ref or "//" in ref or ref.endswith(("/", ".", ".lock")):
+        raise ValueError(f"invalid ref: {ref!r}")
+    return ref
 
 
 def _write_repo_file(rpath: str, parts: list[str], content: str) -> None:
@@ -144,13 +176,19 @@ def list_commits(
 
     Returns list of {sha, message, author_name, author_email, date}.
     """
+    _validate_ref(branch)
     rpath = repo_path(base_path, org_id, repo_name)
     if not os.path.isdir(rpath):
         return []
 
     fmt = "%H%n%s%n%an%n%ae%n%aI"  # sha, subject, author name, author email, ISO date
+    # Every option must precede --end-of-options; git treats everything after it
+    # as a non-option, so a --format= placed later fails to parse.
     result = _run_git(
-        ["log", branch, f"--format={fmt}", f"--skip={offset}", f"--max-count={limit}"],
+        [
+            "log", f"--format={fmt}", f"--skip={offset}", f"--max-count={limit}",
+            "--end-of-options", branch,
+        ],
         cwd=rpath,
     )
     if result.returncode != 0:
@@ -173,10 +211,11 @@ def list_commits(
 
 def count_commits(base_path: str, org_id: str, repo_name: str, branch: str = "main") -> int:
     """Count total commits on a branch."""
+    _validate_ref(branch)
     rpath = repo_path(base_path, org_id, repo_name)
     if not os.path.isdir(rpath):
         return 0
-    result = _run_git(["rev-list", "--count", branch], cwd=rpath)
+    result = _run_git(["rev-list", "--count", "--end-of-options", branch], cwd=rpath)
     if result.returncode != 0:
         return 0
     return int(result.stdout.strip())
@@ -193,12 +232,15 @@ def list_tree(
 
     Returns list of {name, path, type, size}.
     """
+    _validate_ref(ref)
     rpath = repo_path(base_path, org_id, repo_name)
     if not os.path.isdir(rpath):
         return []
 
+    # ``path`` needs no check of its own: git resolves it inside the tree and
+    # refuses anything that leaves the repository ("is outside repository").
     tree_ref = f"{ref}:{path}" if path else ref
-    result = _run_git(["ls-tree", "-l", tree_ref], cwd=rpath)
+    result = _run_git(["ls-tree", "-l", "--end-of-options", tree_ref], cwd=rpath)
     if result.returncode != 0:
         return []
 
@@ -238,11 +280,12 @@ def read_blob(
 
     Returns the content as a string, or None if not found.
     """
+    _validate_ref(ref)
     rpath = repo_path(base_path, org_id, repo_name)
     if not os.path.isdir(rpath):
         return None
 
-    result = _run_git(["show", f"{ref}:{path}"], cwd=rpath)
+    result = _run_git(["show", "--end-of-options", f"{ref}:{path}"], cwd=rpath)
     if result.returncode != 0:
         return None
     return result.stdout
@@ -271,7 +314,10 @@ def create_commit(
         return None
 
     # Validate every path before mutating anything: paths are agent-supplied,
-    # and the write below happens before git sees them.
+    # and the write below happens before git sees them. The branch is checked
+    # for the same reason the read paths check refs — as a lone token it is
+    # option-parseable, and ``checkout --orphan=<name>`` succeeds.
+    _validate_ref(branch)
     parts_by_path = {f["path"]: _validate_rel_path(f["path"]) for f in files}
 
     env = {
@@ -282,7 +328,7 @@ def create_commit(
     }
 
     # Checkout the branch; on failure abort rather than commit elsewhere.
-    if _run_git(["checkout", branch], cwd=rpath, env=env).returncode != 0:
+    if _run_git(["checkout", "--end-of-options", branch], cwd=rpath, env=env).returncode != 0:
         return None
 
     # Apply file changes. Physical (symlink) checks happen inside

--- a/tests/fastapi/test_git_repos.py
+++ b/tests/fastapi/test_git_repos.py
@@ -427,6 +427,51 @@ def test_commit_traversal_paths_rejected(test_client, _git_base_path):
     assert not os.path.exists(os.path.join(_git_base_path, "evil.txt"))
 
 
+def test_option_parseable_refs_rejected(test_client, _git_base_path, tmp_path):
+    """`?branch=--output=<path>` must not reach git as an option.
+
+    Refs are lone argv tokens, so one starting with '-' is parsed as an option.
+    `git log --output=<path>` writes the (agent-authored) commit subject there
+    and the `rev-list` that follows truncates it — an arbitrary write/truncate
+    as the server user. Every ref-taking endpoint must reject it.
+    """
+    _register_human(test_client, "refinject@test.com")
+    agent = _create_agent(test_client)
+    _add_owner(test_client, agent, "refinject@test.com")
+    base = f"/api/agentic/agents/{agent['agent_id']}/repos"
+
+    test_client.post(
+        base, json={"name": "ref-repo"},
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+
+    victim = tmp_path / "victim.txt"
+    victim.write_text("original\n")
+    bad = f"--output={victim}"
+
+    for url, params in (
+        (f"{base}/ref-repo/commits", {"branch": bad}),
+        (f"{base}/ref-repo/tree", {"ref": bad}),
+        (f"{base}/ref-repo/blob/README.md", {"ref": bad}),
+    ):
+        r = test_client.get(url, params=params, headers=_auth(agent["api_key"]))
+        assert r.status_code == 400, f"{url}: {r.status_code} {r.text}"
+
+    # The write branch takes its ref in the body, where the model rejects it.
+    r = test_client.post(
+        f"{base}/ref-repo/commits",
+        json={
+            "message": "x",
+            "files": [{"path": "f.txt", "content": "x", "action": "create"}],
+            "branch": bad,
+        },
+        headers=_write_headers(test_client, agent["api_key"]),
+    )
+    assert r.status_code == 422, r.text
+
+    assert victim.read_text() == "original\n"  # neither overwritten nor truncated
+
+
 def test_commit_git_dir_write_rejected(test_client):
     """Writes into .git/ (hooks, config) are refused by the containment layer."""
     _register_human(test_client, "gitdir@test.com")

--- a/tests/git/test_repo_manager.py
+++ b/tests/git/test_repo_manager.py
@@ -121,6 +121,64 @@ def test_failed_git_action_does_not_fake_success(tmp_path):
     assert repo_manager.count_commits(str(tmp_path), "org1", "r1") == before
 
 
+def test_rejects_option_parseable_refs(tmp_path):
+    """A ref starting with '-' is parsed by git as an option, not a revision.
+
+    ``git log``/``git show`` accept ``--output=<path>`` and write there; a
+    ``rev-list`` that then errors has already truncated the file. Each read sink
+    must refuse the ref outright rather than hand it to git.
+    """
+    repo_manager.init_repo(str(tmp_path), "org1", "r1")
+    victim = tmp_path / "victim.txt"
+    victim.write_text("original\n")
+
+    bad_refs = [
+        f"--output={victim}",          # the write / truncate primitive
+        "--help",                      # any option at all
+        "-",                           # bare dash
+        "main..evil",                  # range syntax
+        "main^{tree}",                 # revision grammar
+        "HEAD@{1}",                    # reflog syntax
+        "refs//heads/main",            # empty component
+        "main.lock",                   # git's own reserved suffix
+        "",                            # empty
+        "a" * 256,                     # over the length cap
+    ]
+    for bad in bad_refs:
+        with pytest.raises(ValueError):
+            repo_manager.list_commits(str(tmp_path), "org1", "r1", branch=bad)
+        with pytest.raises(ValueError):
+            repo_manager.count_commits(str(tmp_path), "org1", "r1", branch=bad)
+        with pytest.raises(ValueError):
+            repo_manager.list_tree(str(tmp_path), "org1", "r1", ref=bad)
+        with pytest.raises(ValueError):
+            repo_manager.read_blob(str(tmp_path), "org1", "r1", bad, "README.md")
+        with pytest.raises(ValueError):
+            repo_manager.create_commit(
+                str(tmp_path), "org1", "r1", "msg",
+                [{"path": "f.txt", "content": "x", "action": "create"}],
+                author_name="agent-1", author_email="agent-1@test",
+                branch=bad,
+            )
+
+    assert victim.read_text() == "original\n"  # neither overwritten nor truncated
+
+
+def test_accepts_legitimate_refs(tmp_path):
+    """The ref check must not break branch names, tags, refs/ paths or SHAs."""
+    repo_manager.init_repo(str(tmp_path), "org1", "r1")
+    rpath = repo_manager.repo_path(str(tmp_path), "org1", "r1")
+    sha = repo_manager.list_commits(str(tmp_path), "org1", "r1")[0]["sha"]
+    assert repo_manager._run_git(["tag", "v1.0.0"], cwd=rpath).returncode == 0
+    assert repo_manager._run_git(["branch", "feature/x_1-2"], cwd=rpath).returncode == 0
+
+    for ref in ("main", "feature/x_1-2", "v1.0.0", "refs/heads/main", sha, sha[:7], "HEAD"):
+        assert repo_manager.read_blob(str(tmp_path), "org1", "r1", ref, "README.md") == "# r1\n"
+        assert repo_manager.list_tree(str(tmp_path), "org1", "r1", ref=ref)
+        assert repo_manager.count_commits(str(tmp_path), "org1", "r1", branch=ref) == 1
+        assert len(repo_manager.list_commits(str(tmp_path), "org1", "r1", branch=ref)) == 1
+
+
 def test_accepts_contained_paths(tmp_path):
     repo_manager.init_repo(str(tmp_path), "org1", "r1")
 


### PR DESCRIPTION
## What and why

Branch/ref values from the repo API reached `git` as lone argv tokens, so one starting with `-` was
parsed as an *option* rather than a revision — `git log`/`git show --output=<path>` write to an
arbitrary file and `rev-list --count --output=<path>` truncates one, giving any authenticated agent a
create-and-truncate primitive as the server user. Refs are now validated before they are built into a
command, and every user-supplied revision is passed after `--end-of-options`.

## How to verify

```bash
pytest tests/git tests/fastapi/test_git_repos.py
```

`test_rejects_option_parseable_refs` and `test_accepts_legitimate_refs` (repo_manager) plus
`test_option_parseable_refs_rejected` (endpoints) are the regression tests; the rest of the files are
the pre-existing containment suite and should stay green. `ruff check` is clean.

To see the primitive the fix removes, run this against a throwaway repo — it writes the commit
subject into `/tmp/PWNED`, and the `rev-list` then truncates it to zero:

```bash
git -C /path/to/any/repo log --output=/tmp/PWNED --format=%s && cat /tmp/PWNED
```

Behaviour through the API: `GET …/repos/{repo}/commits?branch=--output=/tmp/x` (and the same payload
as `?ref=` on `/tree` and `/blob/...`) now returns **400** instead of writing the file; the same value
as `branch` in a `POST …/commits` body returns **422** from the model. Ordinary refs are unaffected —
branch names, tags, `refs/heads/...`, full and abbreviated SHAs, and `HEAD` all still resolve.
