### PR TITLE
Fix cross tenant auth

### DIFF
--- a/clawbits/fastapi/agent_auth.py
+++ b/clawbits/fastapi/agent_auth.py
@@ -27,3 +27,15 @@ def extract_agent(engine, api_key: str):
     if agent is None:
         raise HTTPException(status_code=401, detail="Invalid API key")
     return agent
+
+
+def require_own_agent(agent, agent_id: str) -> None:
+    """Assert the authenticated ``agent`` is the one named in the path.
+
+    ``/api/agentic/*`` routes carry the target agent in the URL while the bearer
+    key identifies the caller. Authenticating without comparing the two turns
+    every such route into a cross-tenant read — and, where the handler calls an
+    ``ensure_*`` helper, a cross-tenant write.
+    """
+    if agent.agent_id.value != agent_id:
+        raise HTTPException(status_code=403, detail="API key does not belong to this agent")

--- a/clawbits/fastapi/clawbits_server.py
+++ b/clawbits/fastapi/clawbits_server.py
@@ -110,7 +110,7 @@ from clawbits.db.table_create import TableCreate
 from clawbits.db.table_read import TableRead
 from clawbits.db.table_write import TableWrite
 from clawbits.domain import EMAIL_DOMAIN, SHARE_DOMAIN
-from clawbits.fastapi.agent_auth import extract_agent
+from clawbits.fastapi.agent_auth import extract_agent, require_own_agent
 from clawbits.fastapi.agent_signup import AgentSignup
 from clawbits.fastapi.avatar_hooks import await_channel_avatar
 from clawbits.fastapi.email_endpoints import EmailEndpoints
@@ -2225,6 +2225,9 @@ class ClawBitsServer(FastAPI):
                 caller = TableRead.get_agent_by_api_key(db, token)
                 if caller is None:
                     raise HTTPException(status_code=401, detail="Invalid API key")
+                # Before the existence lookup, so a foreign handle 403s whether
+                # or not it exists — the 404 must not be an enumeration oracle.
+                require_own_agent(caller, agent_id)
                 info = TableRead.get_agent_info(db, agent_id)
                 if info is None:
                     raise HTTPException(status_code=404, detail="Agent not found")
@@ -2308,7 +2311,10 @@ class ClawBitsServer(FastAPI):
     ) -> MmChannelResponse:
         """Get (or create) the default channel for an agent's organization."""
         try:
-            self._mm_extract_agent(api_key)
+            agent = self._mm_extract_agent(api_key)
+            # Self-scoped: ensure_* creates the channel on miss, so without
+            # this check a read request is also a cross-org write.
+            require_own_agent(agent, agent_id)
             with Session(self._engine) as db:
                 channel = TableWrite.ensure_agent_default_mm_channel(db, agent_id)
                 db.commit()
@@ -2329,7 +2335,11 @@ class ClawBitsServer(FastAPI):
     ) -> MmChannelResponse:
         """Get (or create) the operator-agent direct communication channel."""
         try:
-            self._mm_extract_agent(api_key)
+            agent = self._mm_extract_agent(api_key)
+            # Self-scoped: ensure_* creates the DM (and its membership rows) on
+            # miss, so without this check a read request is also a cross-org
+            # write — and the response previews the operator DM's last message.
+            require_own_agent(agent, agent_id)
             with Session(self._engine) as db:
                 channel, created = TableWrite.ensure_owner_agent_comm_channel(db, agent_id)
                 db.commit()
@@ -4178,8 +4188,7 @@ class ClawBitsServer(FastAPI):
             agent = TableRead.get_agent_by_api_key(db, token)
             if agent is None:
                 raise HTTPException(status_code=401, detail="Invalid API key")
-        if agent.agent_id.value != agent_id:
-            raise HTTPException(status_code=403, detail="API key does not belong to this agent")
+        require_own_agent(agent, agent_id)
 
         with Session(self._engine) as db:
             TableWrite.upsert_agent_action(db, agent_id, body.action_id, body.action_md)
@@ -4206,6 +4215,7 @@ class ClawBitsServer(FastAPI):
             agent = TableRead.get_agent_by_api_key(db, token)
             if agent is None:
                 raise HTTPException(status_code=401, detail="Invalid API key")
+            require_own_agent(agent, agent_id)
             items = TableRead.get_agent_actions(db, agent_id, limit=limit, offset=offset)
             total = TableRead.count_agent_actions_for_agent(db, agent_id)
 
@@ -4230,6 +4240,7 @@ class ClawBitsServer(FastAPI):
             agent = TableRead.get_agent_by_api_key(db, token)
             if agent is None:
                 raise HTTPException(status_code=401, detail="Invalid API key")
+            require_own_agent(agent, agent_id)
             row = TableRead.get_agent_action(db, agent_id, action_id)
 
         if row is None:
@@ -4254,8 +4265,7 @@ class ClawBitsServer(FastAPI):
             agent = TableRead.get_agent_by_api_key(db, token)
             if agent is None:
                 raise HTTPException(status_code=401, detail="Invalid API key")
-        if agent.agent_id.value != agent_id:
-            raise HTTPException(status_code=403, detail="API key does not belong to this agent")
+        require_own_agent(agent, agent_id)
 
         with Session(self._engine) as db:
             deleted = TableWrite.delete_agent_action(db, agent_id, action_id)
@@ -4310,8 +4320,7 @@ class ClawBitsServer(FastAPI):
             agent = TableRead.get_agent_by_api_key(db, token)
             if agent is None:
                 raise HTTPException(status_code=401, detail="Invalid API key")
-        if agent.agent_id.value != agent_id:
-            raise HTTPException(status_code=403, detail="API key does not belong to this agent")
+        require_own_agent(agent, agent_id)
 
         with Session(self._engine) as db:
             TableWrite.upsert_agent_profile(
@@ -4353,8 +4362,7 @@ class ClawBitsServer(FastAPI):
             agent = TableRead.get_agent_by_api_key(db, token)
             if agent is None:
                 raise HTTPException(status_code=401, detail="Invalid API key")
-        if agent.agent_id.value != agent_id:
-            raise HTTPException(status_code=403, detail="API key does not belong to this agent")
+        require_own_agent(agent, agent_id)
 
         with Session(self._engine) as db:
             TableWrite.set_agent_description(db, agent_id, body.description, source="auto")

--- a/clawbits/fastapi/email_endpoints.py
+++ b/clawbits/fastapi/email_endpoints.py
@@ -30,7 +30,7 @@ from clawbits.email.imap_client import (
 from clawbits.email.smtp_client import STALWART_SMTP_HOST
 from clawbits.email.smtp_client import send_email as smtp_send_email
 from clawbits.email.stalwart_provision import provision_mailbox
-from clawbits.fastapi.agent_auth import extract_agent
+from clawbits.fastapi.agent_auth import extract_agent, require_own_agent
 from clawbits.gas.cost_decorator import cost
 
 api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
@@ -58,11 +58,7 @@ class EmailEndpoints:
     @staticmethod
     def _require_mailbox_owner(agent, agent_id: str):
         """Verify the authenticated agent owns the requested mailbox."""
-        if agent.agent_id.value != agent_id:
-            raise HTTPException(
-                status_code=403,
-                detail="API key does not belong to this agent",
-            )
+        require_own_agent(agent, agent_id)
 
     @staticmethod
     def _check_stalwart_configured():

--- a/clawbits/fastapi/git_endpoints.py
+++ b/clawbits/fastapi/git_endpoints.py
@@ -23,7 +23,7 @@ from clawbits.datastructures.git_models import (
 from clawbits.db.table_read import TableRead
 from clawbits.db.table_write import TableWrite
 from clawbits.email.imap_client import agent_email_address
-from clawbits.fastapi.agent_auth import extract_agent
+from clawbits.fastapi.agent_auth import extract_agent, require_own_agent
 from clawbits.gas.cost_decorator import cost
 from clawbits.git import repo_manager
 
@@ -48,8 +48,7 @@ class GitEndpoints:
 
     @staticmethod
     def _require_own_agent(agent, agent_id: str):
-        if agent.agent_id.value != agent_id:
-            raise HTTPException(status_code=403, detail="API key does not belong to this agent")
+        require_own_agent(agent, agent_id)
 
     @staticmethod
     def _resolve_org(server, agent_id: str, org_id: str | None) -> str:

--- a/docs/protocol/AGENT_AND_HUMAN_MESSAGING_API.md
+++ b/docs/protocol/AGENT_AND_HUMAN_MESSAGING_API.md
@@ -36,6 +36,7 @@ The default channel includes all members of the agent's owner organization.
 
 **Error Responses**
 - `401 Unauthorized`: Invalid or missing bearer token.
+- `403 Forbidden`: API key does not belong to `{agent_id}` — agents can only fetch their own default channel.
 - `404 Not Found`: Agent has no organization.
 
 ---
@@ -64,6 +65,7 @@ Get or create the private direct-message channel between the agent and its prima
 
 **Error Responses**
 - `401 Unauthorized`: Invalid or missing bearer token.
+- `403 Forbidden`: API key does not belong to `{agent_id}` — agents can only fetch their own operator channel.
 - `404 Not Found`: Agent has no operator.
 
 ---

--- a/docs/protocol/AGENT_OWNERS_API.md
+++ b/docs/protocol/AGENT_OWNERS_API.md
@@ -38,6 +38,7 @@ Return the agent's organization and operator details.
 
 **Error Responses**
 - `401 Unauthorized`: Invalid API key.
+- `403 Forbidden`: API key does not belong to `{agent_id}` — agents can only read their own info.
 - `404 Not Found`: Agent not found.
 - `426 Upgrade Required`: Plugin version header was sent but is below the server's minimum.
 

--- a/docs/protocol/CHANNELS_AND_MESSAGING_PROCEDURES_SPEC.md
+++ b/docs/protocol/CHANNELS_AND_MESSAGING_PROCEDURES_SPEC.md
@@ -110,7 +110,7 @@ The default channel is created **lazily** on the first call to:
 ```
 GET /api/agentic/mm/teams/{agent_id}/default-channel
 ```
-This endpoint is idempotent — it returns the existing channel or creates it if missing. Human members of the organization are added to the default channel incrementally as they join the org, not all at once at creation time.
+This endpoint is idempotent — it returns the existing channel or creates it if missing. It is self-scoped: the bearer key must belong to `{agent_id}` (403 otherwise), so only the agent itself can trigger the lazy creation. Human members of the organization are added to the default channel incrementally as they join the org, not all at once at creation time.
 
 ---
 

--- a/docs/protocol/SKILLS_LIBRARY_PLAN.md
+++ b/docs/protocol/SKILLS_LIBRARY_PLAN.md
@@ -465,11 +465,13 @@ Shipping a skills library beside a leaking competitor feature is not acceptable:
   `agent_actions` is the closest existing "agent instruction document" feature
   to skills; it has no `org_id`, no versioning and no lifecycle. Recommend
   deleting these endpoints rather than extending the model.
-- `GET /api/agentic/agents/{agent_id}/info` authenticates the bearer as *some*
+- ~~`GET /api/agentic/agents/{agent_id}/info` authenticates the bearer as *some*
   agent, then returns whatever `agent_id` was asked for - leaking any agent's
-  org, operator id and operator email across orgs
-  (`clawbits_server.py:2132`). The `_require_own_agent` pattern already exists
-  at `git_endpoints.py:49-51`.
+  org, operator id and operator email across orgs~~ **Fixed:** `/info` and the
+  per-agent action reads are now self-scoped via the shared
+  `require_own_agent` in `agent_auth.py` (403 on mismatch). The unscoped
+  cross-org listings (`GET /api/{human,agentic}/actions`) remain as described
+  above.
 
 Note that org isolation here is enforced **by convention** - no row-level
 security, no query-time filter, no `Depends(require_org)`. One forgotten check

--- a/tests/fastapi/test_action.py
+++ b/tests/fastapi/test_action.py
@@ -186,6 +186,30 @@ def test_get_action_no_auth(test_client):
     assert r.status_code == 401
 
 
+def test_get_action_wrong_agent(test_client):
+    """Per-agent action reads are self-scoped like their write siblings."""
+    a1 = _create_agent(test_client)
+    a2 = _create_agent(test_client)
+
+    test_client.put(
+        f"/api/agentic/agents/{a1['agent_id']}/actions",
+        json={"action_id": "default", "action_md": "# Private"},
+        headers=_write_headers(test_client, a1["api_key"]),
+    )
+
+    r = test_client.get(
+        f"/api/agentic/agents/{a1['agent_id']}/actions/default",
+        headers=_auth(a2["api_key"]),
+    )
+    assert r.status_code == 403, r.text
+
+    r = test_client.get(
+        f"/api/agentic/agents/{a1['agent_id']}/actions",
+        headers=_auth(a2["api_key"]),
+    )
+    assert r.status_code == 403, r.text
+
+
 # ---------------------------------------------------------------------------
 # Tests: DELETE action
 # ---------------------------------------------------------------------------

--- a/tests/fastapi/test_agent_info.py
+++ b/tests/fastapi/test_agent_info.py
@@ -50,6 +50,29 @@ def test_info_requires_auth(test_client):
     assert resp.status_code == 401
 
 
+def test_info_rejects_other_agents_key(test_client):
+    """/info is self-scoped: another agent's key gets 403, not operator PII."""
+    victim = _create_agent(test_client)
+    intruder = _create_agent(test_client)
+
+    resp = test_client.get(
+        f"/api/agentic/agents/{victim['agent_id']}/info",
+        headers={"Authorization": f"Bearer {intruder['api_key']}"},
+    )
+    assert resp.status_code == 403, resp.text
+    assert "operator_email" not in resp.json()
+
+
+def test_info_unknown_agent_is_403_not_404(test_client):
+    """A foreign handle 403s whether or not it exists — no enumeration oracle."""
+    agent = _create_agent(test_client)
+    resp = test_client.get(
+        "/api/agentic/agents/no_such_agent/info",
+        headers={"Authorization": f"Bearer {agent['api_key']}"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
 def test_only_operator_can_change_settings(test_client):
     """A non-operator org member cannot change an agent's settings."""
     other_email = _unique_email("non-op")

--- a/tests/fastapi/test_mattermost.py
+++ b/tests/fastapi/test_mattermost.py
@@ -180,6 +180,45 @@ def test_agent_default_channel_exists_on_creation(test_client):
     assert any(m.get("agent_id") == agent["agent_id"] for m in members)
 
 
+def test_default_channel_rejects_other_agents_key(test_client):
+    """default-channel is self-scoped: a foreign key gets 403 and no channel data."""
+    owner = _create_owned_agent(test_client)
+    intruder = _create_owned_agent(test_client)
+
+    r = test_client.get(
+        f"/api/agentic/mm/teams/{owner['agent_id']}/default-channel",
+        headers=_auth(intruder["api_key"]),
+    )
+    assert r.status_code == 403, r.text
+    assert "channel_id" not in r.json()
+
+
+def test_operator_channel_rejects_other_agents_key(test_client):
+    """operator-channel is self-scoped: 403 for a foreign key, and the ensure_
+    write must not run — no channel row is created or touched for the victim."""
+    from sqlmodel import Session, func, select
+
+    from clawbits.db.models import MmChannel
+
+    owner = _create_owned_agent(test_client)
+    intruder = _create_owned_agent(test_client)
+
+    server = test_client.app
+    with Session(server._engine) as s:
+        channels_before = s.exec(select(func.count()).select_from(MmChannel)).one()
+
+    r = test_client.get(
+        f"/api/agentic/mm/teams/{owner['agent_id']}/operator-channel",
+        headers=_auth(intruder["api_key"]),
+    )
+    assert r.status_code == 403, r.text
+    assert "last_message_text" not in r.json()
+
+    with Session(server._engine) as s:
+        channels_after = s.exec(select(func.count()).select_from(MmChannel)).one()
+    assert channels_after == channels_before
+
+
 # ---------------------------------------------------------------------------
 # Tests: Channels
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What and why

Any valid agent API key could read **any other agent's** `/info` — leaking the operator's
email address, org identity, and internal Ollama endpoint platform-wide — and could fetch
another agent's mm channels, which both previewed the last message of that operator's
private DM and, via the `ensure_*` helpers, **created** channel and membership rows inside
the victim's org (audit findings 04 and 05). This PR adds a shared `require_own_agent()`
check (`agent_auth.py`) and enforces caller-is-subject on `get_agent_info`,
`mm_get_default_channel`, `mm_get_operator_channel`, and the two per-agent action reads
(`get_agent_actions`, `get_action`) — the previously unchecked read siblings of
already-checked writes. The six pre-existing copies of the same check (git, email, and
four inline in `clawbits_server.py`) now delegate to the shared helper; status code and
detail string are unchanged.

## How to verify

    pytest tests/fastapi/test_agent_info.py tests/fastapi/test_mattermost.py tests/fastapi/test_action.py -q

The five new tests (`test_info_rejects_other_agents_key`,
`test_info_unknown_agent_is_403_not_404`, `test_default_channel_rejects_other_agents_key`,
`test_operator_channel_rejects_other_agents_key`, `test_get_action_wrong_agent`) assert the
403, that the response carries no `operator_email` / `last_message_text`, and that the
operator-channel probe leaves the `mm_channels` row count untouched (the ensure-write
regression). Or probe by hand — create two agents, then with agent B's key:

    curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $B_KEY" \
      "$HOST/api/agentic/agents/$A_ID/info"        # 403 (was 200 + operator PII)

Same call with A's own key still returns 200 with the full payload.

## Notes

- **No client breaks.** Every production caller (plugin `setup-flow.ts`, hermes
  `adapter.py`/`signup.py`, ironclaw `onboarding_message.py`) passes its own agent id,
  paired with the key issued for it; `default-channel` has no production caller at all.
- **Ordering:** the ownership check runs *before* the existence lookup, so a foreign
  handle 403s whether or not it exists — the 404 is no longer a handle-enumeration oracle.
- **Deliberately not done:** splitting the `ensure_*` get-or-create semantics (suggested
  in finding 05). Self-scoping already confines creation to the agent's own install-time
  provisioning, which plugin and hermes signup depend on; noted in code comments instead.
- **Left public by design** (follow-up product call, not fixed here): `get_agent_posts`,
  `get_agent_profile`, and the unscoped `GET /api/{human,agentic}/actions` listings — each
  has an intentionally public sibling exposing the same data.
- Full suite: 893 passed (email tests excluded — the ~20 local failures there are the
  pre-existing Stalwart-infra baseline, unrelated); `ruff check` clean; plugin 357/357.

---

- [ ] Commits signed off (`git commit -s`) — see [CONTRIBUTING](CONTRIBUTING.md#sign-off-dco)
- [ ] Conventional commit subject (`feat:` / `fix:` / `chore:` …) — this decides the version bump
- [x] Tests added or updated for behaviour changes
- [x] `db_schema.md` regenerated if a model changed, and a migration added — n/a, no model change