### PR TITLE
Fix desktop app auth

### DIFF
--- a/clawbits/domain.py
+++ b/clawbits/domain.py
@@ -30,3 +30,25 @@ SHARE_DOMAIN: str = os.getenv("CUSTOM_DOMAIN", f"share.{BASE_DOMAIN}")
 EMAIL_DOMAIN: str = os.getenv("STALWART_EMAIL_DOMAIN", BASE_DOMAIN)
 SYSTEM_EMAIL: str = f"system@{BASE_DOMAIN}"
 
+
+# ---------------------------------------------------------------------------
+# Environment gate for debug-only surfaces
+# ---------------------------------------------------------------------------
+# Environments that count as "development" for security gates. A gate keyed on
+# this set fails CLOSED: unset / empty / unknown ``CLAWBITS_ENV`` is NOT dev.
+#
+# Contrast ``IS_PRODUCTION`` above, which is evaluated at import time and fails
+# OPEN (unset -> "development" -> not production). That constant is a
+# *domain-selection* switch and must never be used as a security gate — reach
+# for ``is_dev_env()`` for anything safety-relevant.
+DEV_ENVS = frozenset({"development", "dev", "local", "test"})
+
+
+def is_dev_env() -> bool:
+    """True when ``CLAWBITS_ENV`` names a development environment.
+
+    Reads ``os.environ`` on every call — deliberately *not* the module-level
+    ``CLAWBITS_ENV`` constant, which is frozen at import time and would make
+    every gate built on this untestable.
+    """
+    return (os.environ.get("CLAWBITS_ENV") or "").strip().lower() in DEV_ENVS

--- a/clawbits/fastapi/clawbits_server.py
+++ b/clawbits/fastapi/clawbits_server.py
@@ -131,6 +131,7 @@ from clawbits.fastapi.search_helpers import (
     encode_search_cursor,
     parse_search_date,
 )
+from clawbits.fastapi.trace_store import is_valid_trace_id
 from clawbits.fastapi.version_check import (
     build_version_check_response,
     parse_plugin_kind,
@@ -290,6 +291,12 @@ class ClawBitsServer(FastAPI):
             # round-trip. See the end-to-end latency tracer; the structured
             # ``TRACE`` line below is what the collator stitches on.
             trace_id = request.headers.get("x-clawbits-trace-id")
+            # Attacker-controlled header. Anything malformed or over-long is
+            # treated as absent: it is echoed into the ``TRACE`` log line below,
+            # which is deliberately NOT covered by the tracer's dev-only gate,
+            # and would otherwise become an unbounded ring key.
+            if trace_id is not None and not is_valid_trace_id(trace_id):
+                trace_id = None
             start = time.monotonic()
             status_code = 500
             try:

--- a/clawbits/fastapi/dev_auth.py
+++ b/clawbits/fastapi/dev_auth.py
@@ -24,6 +24,7 @@ from sqlmodel import Session
 from clawbits.db.models import DISPLAY_NAME_MAX_LENGTH
 from clawbits.db.table_read import TableRead
 from clawbits.db.table_write import TableWrite
+from clawbits.domain import DEV_ENVS, is_dev_env
 from clawbits.fastapi.session_cookie import (
     auth_log,
     stage_dev_session_set,
@@ -36,14 +37,14 @@ log = logging.getLogger(__name__)
 DEV_WORKOS_ID_PREFIX = "dev:"
 DEV_WORKOS_ORG_ID_PREFIX = "dev-org:"
 
-_DEV_ENVS = frozenset({"development", "dev", "local", "test"})
-
 
 def _gate_signals() -> tuple[bool, str | None]:
     """Returns ``(enabled, reason_if_disabled_or_conflict)``."""
     flag = os.environ.get("CLAWBITS_DEV_AUTH") == "1"
+    # ``env_raw`` is kept only for the operator-facing reason string below;
+    # the gate itself defers to the shared fail-closed predicate.
     env_raw = (os.environ.get("CLAWBITS_ENV") or "").strip().lower()
-    env_is_dev = env_raw in _DEV_ENVS
+    env_is_dev = is_dev_env()
 
     if not flag:
         return False, "CLAWBITS_DEV_AUTH not set"
@@ -51,7 +52,7 @@ def _gate_signals() -> tuple[bool, str | None]:
     if not env_is_dev:
         return False, (
             f"CLAWBITS_DEV_AUTH=1 but CLAWBITS_ENV={env_raw or '(unset)'!r} "
-            f"is not in {sorted(_DEV_ENVS)}. Refusing to enable dev auth."
+            f"is not in {sorted(DEV_ENVS)}. Refusing to enable dev auth."
         )
     return True, None
 
@@ -88,7 +89,7 @@ def assert_safe_at_startup() -> None:
 
     raise RuntimeError(
         f"Refusing to start: dev-auth signals are misconfigured. {reason} "
-        f"Set CLAWBITS_ENV to one of {sorted(_DEV_ENVS)}, or unset CLAWBITS_DEV_AUTH.",
+        f"Set CLAWBITS_ENV to one of {sorted(DEV_ENVS)}, or unset CLAWBITS_DEV_AUTH.",
     )
 
 

--- a/clawbits/fastapi/main.py
+++ b/clawbits/fastapi/main.py
@@ -294,7 +294,9 @@ app.include_router(human_mm_router)
 app.include_router(contact_permissions_router)
 app.include_router(push_router)
 # Standalone trace viewer (sink + read API + /trace page). Registered before
-# the SPA catch-all below so its explicit routes win.
+# the SPA catch-all below so its explicit routes win. Mounted unconditionally
+# like dev_auth_router: the dev-only gate is a router dependency evaluated per
+# request (see trace_endpoints._require_trace_enabled), not an import-time if.
 app.include_router(trace_router)
 
 # ---------------------------------------------------------------------------

--- a/clawbits/fastapi/trace_endpoints.py
+++ b/clawbits/fastapi/trace_endpoints.py
@@ -1,39 +1,84 @@
 """Standalone end-to-end latency trace viewer — sink, read API, and static page.
 
-Deliberately decoupled from the React SPA: no build step, no router, no auth
-coupling. A single self-contained ``trace_viewer.html`` is served at ``/trace``
-and talks to the read endpoints below; subsystems ship their spans to the sink.
+Deliberately decoupled from the React SPA: no build step, no router. A single
+self-contained ``trace_viewer.html`` is served at ``/trace`` and talks to the
+read endpoints below; subsystems ship their spans to the sink.
 
   POST /api/trace/spans         — span sink (one span, or a list). Best-effort.
   GET  /api/trace/traces        — recent traces (summaries), newest-active first.
   GET  /api/trace/traces/{id}   — all spans for one trace, ordered for a waterfall.
   GET  /trace                   — the viewer page itself.
 
+**Development only.** Every route here is gated on ``trace_store.is_trace_enabled``
+and 404s outside a dev ``CLAWBITS_ENV``: the read side is an unauthenticated map
+of internal endpoints plus a cross-user activity timeline, and the write side is
+an unauthenticated sink into a page that renders what it stores. There is no
+operator role in this codebase to gate on instead, and the only auth dependency
+(``get_current_human_user``) is binary any-registered-human — which would expose
+every user's traffic to every other user while silently 401ing both emitters,
+neither of which authenticates its span POST.
+
 The store is an in-memory ring (see ``trace_store``); restarting the server
 clears it. This is a live debugging surface, not durable telemetry.
+
+Note the viewer page has only ever been reachable on direct app access
+(``localhost:8000``, or a port-forward) — both nginx configs route ``/`` to the
+frontend container, so ``/trace`` through the proxy serves the SPA. That is
+pre-existing and unrelated to the gate above.
 """
 from __future__ import annotations
 
 import os
-from typing import Any
 
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
 
 from clawbits.fastapi import trace_store
 
-trace_router = APIRouter()
-
 _VIEWER_HTML = os.path.join(os.path.dirname(__file__), "trace_viewer.html")
+
+# One POST can carry a list of spans. Bound the work per request: nginx allows
+# a 25m body, and the ring itself caps at 200 spans per trace anyway.
+_MAX_SPANS_PER_POST = 200
+
+
+def _require_trace_enabled() -> None:
+    """404 (not 403) when the tracer is off, so it leaves no detectable surface
+    in prod — the same contract ``dev_auth`` uses for its own dev-only routes.
+
+    Declared on the router rather than per-route so it covers every route in
+    this module, including any added later.
+    """
+    if not trace_store.is_trace_enabled():
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+trace_router = APIRouter(dependencies=[Depends(_require_trace_enabled)])
 
 
 @trace_router.post("/api/trace/spans", include_in_schema=False)
-async def ingest_spans(payload: Any = Body(...)) -> JSONResponse:
+async def ingest_spans(request: Request) -> JSONResponse:
     """Accept one span object or a list of them. Always 200s — tracing is
-    best-effort and must never surface an error back to an emitter."""
+    best-effort and must never surface an error back to an emitter.
+
+    Takes the raw ``Request`` rather than declaring a ``Body(...)`` parameter on
+    purpose: FastAPI reads and JSON-decodes a declared body *before* router
+    dependencies run, so a malformed payload would answer 422 even with the gate
+    off — an enumeration signal that defeats the 404 contract above. Parsing
+    here keeps the gate strictly first, and avoids buffering an arbitrary body
+    on a disabled endpoint.
+
+    ``accepted`` counts the dicts handed to the store, not the spans it retained
+    after sanitising. That is the pre-existing semantics, and both emitters
+    ignore the response.
+    """
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001 - a malformed emitter payload is not an error
+        return JSONResponse({"accepted": 0})
     spans = payload if isinstance(payload, list) else [payload]
     accepted = 0
-    for span in spans:
+    for span in spans[:_MAX_SPANS_PER_POST]:
         if isinstance(span, dict):
             trace_store.add_span(span)
             accepted += 1

--- a/clawbits/fastapi/trace_store.py
+++ b/clawbits/fastapi/trace_store.py
@@ -14,14 +14,23 @@ round-trip. Storage is a bounded, newest-wins ring held only in process memory:
 no migration, no durability across restarts — deliberately, this is a live
 debug tool, not an audit log. Bump ``_MAX_TRACES`` if you need a deeper history.
 
+**Development only.** The ring is an unauthenticated cross-user activity
+timeline, so ``add_span`` no-ops unless ``CLAWBITS_ENV`` names a dev
+environment (see ``is_trace_enabled``). Production observability is unaffected:
+the server's structured ``TRACE`` log line is emitted independently of this
+ring. Everything that lands here is sanitised first — see ``_sanitize``.
+
 Clock-skew caveat (inherited from the span emitters): cross-process ``t_*_ms``
 deltas are only exact on a single host; across machines the bars can drift.
 """
 from __future__ import annotations
 
+import re
 import threading
 from collections import OrderedDict
 from typing import Any
+
+from clawbits.domain import is_dev_env
 
 # Newest-wins ring: at most this many distinct traces are retained. A human-
 # paced channel produces a handful of spans per round-trip, so this is plenty
@@ -36,6 +45,107 @@ _lock = threading.Lock()
 # to the end whenever a new span lands so the most *recently active* traces win
 # eviction, not merely the most recently created.
 _traces: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
+
+
+def is_trace_enabled() -> bool:
+    """Whether the debug tracer accepts writes and serves reads. Fails closed.
+
+    Dev-only by design: the ring is an unauthenticated cross-user activity
+    timeline and the viewer page exposes the internal endpoint map, so it must
+    never be live in a real deployment. There is no admin/operator role in this
+    codebase to gate it on, and the one auth dependency we do have
+    (``get_current_human_user``) is binary any-registered-human — which would
+    still expose every user's traffic to every other user. Env is the right gate.
+
+    Both writers funnel through ``add_span`` — the HTTP sink in
+    ``trace_endpoints`` and the in-process push from
+    ``clawbits_server.request_duration_middleware`` — so gating there closes
+    every write path at once. Unmounting the router would not: the middleware
+    imports this module directly.
+    """
+    return is_dev_env()
+
+
+# --- Input hardening -------------------------------------------------------
+# Defence in depth. After the gate above the write path is dev-only, but the
+# sink stays unauthenticated there, so a span must not be able to carry markup
+# into the viewer or pin unbounded memory. Every cap below has ~2x headroom
+# over the largest value a real emitter sends.
+_KNOWN_SUBSYSTEMS = frozenset({"frontend", "server", "plugin"})
+_OTHER_SUBSYSTEM = "other"
+# 64 matches ``mm_models.MmPostRequest.trace_id``, so any id that legitimately
+# round-trips a post fits by construction (the frontend mints ``tr_<uuid4>``,
+# 39 chars). The charset excludes ``<>"'&``, whitespace and control characters:
+# ``server.http``'s id comes straight from the ``x-clawbits-trace-id`` header.
+_MAX_TRACE_ID_LEN = 64
+_TRACE_ID_RE = re.compile(rf"[A-Za-z0-9_.:-]{{1,{_MAX_TRACE_ID_LEN}}}")
+_MAX_SPAN_NAME_LEN = 128
+_TIMING_KEYS = ("t_start_ms", "t_end_ms", "dur_ms")
+_MAX_KEY_LEN = 64
+_MAX_VALUE_LEN = 256
+_MAX_SPAN_KEYS = 24
+
+
+def is_valid_trace_id(trace_id: object) -> bool:
+    """A trace id must be short and boring: it is the ring key, it is echoed
+    into the server's ``TRACE`` log line, and the viewer renders it into HTML.
+    """
+    return isinstance(trace_id, str) and _TRACE_ID_RE.fullmatch(trace_id) is not None
+
+
+def _sanitize(span: dict[str, Any]) -> dict[str, Any] | None:
+    """Coerce one emitter-supplied span into a bounded, scalar-only dict.
+
+    Returns ``None`` only for an unusable ``trace_id`` — every other field is
+    normalised or truncated rather than dropped, so a legitimate span never
+    disappears just because one attribute was odd.
+    """
+    trace_id = span.get("trace_id")
+    if not is_valid_trace_id(trace_id):
+        return None
+
+    # Core keys first so they always survive the key cap below.
+    out: dict[str, Any] = {"trace_id": trace_id}
+
+    # Display-only, so truncating costs no timing data. Never ``str()`` a
+    # container first — that materialises an arbitrarily large string before
+    # we get a chance to slice it.
+    name = span.get("span")
+    out["span"] = name[:_MAX_SPAN_NAME_LEN] if isinstance(name, str) else "unknown"
+
+    # Feeds the viewer's badge class and bar colour. Bucket to "other" (which
+    # the viewer already renders) rather than dropping the span. The isinstance
+    # guard is load-bearing: a JSON value can be a list or dict, and testing
+    # those for membership of a frozenset raises TypeError.
+    sub = span.get("subsystem")
+    out["subsystem"] = sub if isinstance(sub, str) and sub in _KNOWN_SUBSYSTEMS else _OTHER_SUBSYSTEM
+
+    # Timings: numbers or nothing. ``_trace_bounds`` and the waterfall sort
+    # already assume that, and a string here would render as "NaNs" in the
+    # viewer's bar label. ``bool`` is an ``int`` subclass, hence the exclusion.
+    for key in _TIMING_KEYS:
+        value = span.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            out[key] = value
+
+    # Free-form attributes: JSON scalars only. No real emitter sends a nested
+    # structure, and allowing one would leave the span unbounded in size — a
+    # per-string cap alone does not bound a nested dict.
+    for key, value in span.items():
+        if not isinstance(key, str) or len(key) > _MAX_KEY_LEN or key in out:
+            continue
+        # A timing key absent from ``out`` was *rejected* above, not missed —
+        # don't let the generic scalar rule quietly re-admit it.
+        if key in _TIMING_KEYS:
+            continue
+        if len(out) >= _MAX_SPAN_KEYS:
+            break
+        if isinstance(value, str):
+            out[key] = value[:_MAX_VALUE_LEN]
+        elif value is None or isinstance(value, (bool, int, float)):
+            out[key] = value
+        # dict / list / anything else: dropped.
+    return out
 
 
 def _normalize(span: dict[str, Any]) -> dict[str, Any]:
@@ -57,14 +167,22 @@ def _normalize(span: dict[str, Any]) -> dict[str, Any]:
 def add_span(span: dict[str, Any]) -> None:
     """Record one span. No-op (silently) for spans without a real ``trace_id``.
 
-    Untraced spans (``trace_id`` null/empty) carry no correlation value for the
-    viewer, so they're dropped here rather than bucketed. Tracing must never be
-    able to break a request, so callers should treat this as best-effort.
+    Untraced spans (``trace_id`` null/empty/malformed) carry no correlation
+    value for the viewer, so they're dropped here rather than bucketed. Tracing
+    must never be able to break a request, so callers should treat this as
+    best-effort.
+
+    No-ops entirely outside development — see ``is_trace_enabled``. This is the
+    single choke point for both writers, so the check belongs here rather than
+    around the router.
     """
-    trace_id = span.get("trace_id")
-    if not isinstance(trace_id, str) or not trace_id:
+    if not is_trace_enabled():
         return
-    s = _normalize(span)
+    sanitized = _sanitize(span)
+    if sanitized is None:
+        return
+    trace_id = sanitized["trace_id"]
+    s = _normalize(sanitized)
     with _lock:
         spans = _traces.get(trace_id)
         if spans is None:

--- a/clawbits/fastapi/trace_viewer.html
+++ b/clawbits/fastapi/trace_viewer.html
@@ -81,7 +81,10 @@
 const SUBS = ["frontend", "server", "plugin"];
 function subClass(s) { return SUBS.includes(s) ? "b-" + s : "b-other"; }
 function barColor(s) {
-  return { frontend: "var(--frontend)", server: "var(--server)", plugin: "var(--plugin)" }[s] || "var(--other)";
+  // Allow-list, mirroring subClass above. A bare object-literal lookup returns
+  // an *inherited* member for a crafted subsystem ("constructor", "toString",
+  // "valueOf") and stringifies a function straight into the style attribute.
+  return SUBS.includes(s) ? `var(--${s})` : "var(--other)";
 }
 function fmtMs(ms) {
   if (ms == null) return "—";
@@ -110,11 +113,13 @@ async function loadList() {
     el.innerHTML = '<div class="empty">No traces yet. Send a message in the app, then refresh.</div>';
     return;
   }
+  // data-id below is encodeURIComponent'd, which is safe ONLY because the
+  // attribute is double-quoted: it escapes " to %22 but leaves ' intact.
   el.innerHTML = data.traces.map((t) => `
     <div class="trace-row ${t.trace_id === selected ? "active" : ""}" data-id="${encodeURIComponent(t.trace_id)}">
-      <div><span class="dur">${fmtMs(t.total_ms)}</span><span class="tid">${t.trace_id}</span></div>
+      <div><span class="dur">${fmtMs(t.total_ms)}</span><span class="tid">${escapeHtml(t.trace_id)}</span></div>
       <div class="meta">
-        ${t.subsystems.map((s) => `<span class="badge ${subClass(s)}">${s}</span>`).join("")}
+        ${t.subsystems.map((s) => `<span class="badge ${subClass(s)}">${escapeHtml(s)}</span>`).join("")}
         ${t.span_count} spans · ${fmtClock(t.t_start_ms)}
       </div>
     </div>`).join("");
@@ -145,7 +150,7 @@ function renderWaterfall(trace) {
     const width = Math.max((dur / span) * 100, 0.5);
     return `
       <div class="row">
-        <div class="label" title="${s.span}">${s.span}</div>
+        <div class="label" title="${escapeHtml(s.span)}">${escapeHtml(s.span)}</div>
         <div class="track">
           <div class="bar" style="left:${left}%;width:${width}%;background:${barColor(s.subsystem)}">
             <span class="barlabel">${fmtMs(dur)}</span>
@@ -155,7 +160,7 @@ function renderWaterfall(trace) {
   }).join("");
   document.getElementById("detail").innerHTML = `
     <div class="wf-head">
-      <div class="tid">${trace.trace_id}</div>
+      <div class="tid">${escapeHtml(trace.trace_id)}</div>
       <div class="total">total ${fmtMs(trace.total_ms)} · ${trace.spans.length} spans · start ${fmtClock(t0)}</div>
     </div>
     <div class="axis"><div class="label"></div><div class="track"><span>0</span><span class="end">${fmtMs(span)}</span></div></div>
@@ -165,8 +170,13 @@ function renderWaterfall(trace) {
     earliest span. Cross-process timings are exact on a single host; across machines clock skew can shift bars.</div>`;
 }
 
+// INVARIANT: every interpolation into an innerHTML template below MUST go
+// through this. Span fields come straight from the POST sink and can be any
+// JSON type, so coerce with String(); quotes are escaped because several of
+// those sinks sit inside HTML attributes.
 function escapeHtml(s) {
-  return s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]);
 }
 
 loadList();

--- a/clawbits/fastapi/workos_auth.py
+++ b/clawbits/fastapi/workos_auth.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import threading
 import time
@@ -906,6 +907,13 @@ _SOCIAL_PROVIDERS: dict[str, str] = {
     "github": "GitHubOAuth",
 }
 
+# Nonce a native client mints for itself before handing the login off to the
+# system browser, echoed back to it in the deep link. Charset excludes "."
+# because that is the separator in the native ``state`` layout below; the
+# length floor keeps a client from weakening its own binding to something
+# guessable. See :func:`_split_native_state`.
+_CLIENT_STATE_RE = re.compile(r"[A-Za-z0-9_-]{16,64}")
+
 
 @workos_router.get("/social/{provider}/start")
 def social_start(
@@ -914,6 +922,7 @@ def social_start(
     desktop: int = 0,
     bridge: str = "",
     next: str = "",
+    client_state: str = "",
 ):
     """Redirect the browser to the provider via WorkOS.
 
@@ -939,13 +948,27 @@ def social_start(
     cookie rather than the OAuth ``state`` (see OAUTH_RETURN_TO_COOKIE) and is
     validated on the way in AND on the way out — a cookie is not a trust
     boundary, and re-checking at the redirect costs nothing.
+
+    ``client_state`` is a nonce the native client minted for itself. We
+    carry it through the WorkOS round trip and hand it back in the deep
+    link so the client can tell a callback from a login *it* started
+    apart from a ``clawbits://oauth-callback?token=…`` URL fired by a
+    hostile web page. It rides inside ``state`` rather than in its own
+    cookie so it inherits the ``state == cookie`` equality check in
+    :func:`social_callback` — an attacker who rewrites the nonce on the
+    callback URL invalidates the whole flow.
     """
+    if client_state and not _CLIENT_STATE_RE.fullmatch(client_state):
+        # Fail loudly rather than dropping the nonce: a silently discarded
+        # binding is a silently downgraded login.
+        raise HTTPException(status_code=400, detail="Invalid client_state")
+
     client = _client(request)
     state_token = secrets.token_urlsafe(24)
     if bridge == "deeplink":
-        state = f"mobile.{state_token}"
+        state = f"mobile.{client_state}.{state_token}"
     elif desktop:
-        state = f"desktop.{state_token}"
+        state = f"desktop.{client_state}.{state_token}"
     else:
         state = state_token
     auth_url = client.user_management.get_authorization_url(
@@ -973,6 +996,22 @@ def social_start(
         # previous one's destination.
         response.delete_cookie(OAUTH_RETURN_TO_COOKIE, path="/")
     return response
+
+
+def _split_native_state(state: str) -> tuple[str | None, str]:
+    """Split a native-client OAuth ``state`` into ``(kind, client_nonce)``.
+
+    Native states are ``<kind>.<nonce>.<random>`` where *kind* is
+    ``desktop`` or ``mobile`` and *nonce* is the client-minted value from
+    ``?client_state=`` (empty when the client sent none). The two-segment
+    ``<kind>.<random>`` form predates the nonce and is still accepted, so
+    a flow started before a deploy can still finish after it. Web states
+    carry no prefix and yield ``(None, "")``.
+    """
+    parts = state.split(".", 2)
+    if len(parts) < 2 or parts[0] not in ("desktop", "mobile"):
+        return None, ""
+    return parts[0], parts[1] if len(parts) == 3 else ""
 
 
 @workos_router.get("/social/callback")
@@ -1072,8 +1111,9 @@ async def social_callback(
     # the browser tab after firing the deep link. window.close() is honored
     # by Chrome on protocol-handler tabs; Safari is hit-or-miss, hence the
     # visible "you can close this tab" fallback.
+    native_kind, client_state = _split_native_state(state)
     deep_link_scheme: str | None = None
-    if state.startswith("desktop."):
+    if native_kind == "desktop":
         # The desktop binary registers a channel-specific URL scheme so
         # prod, staging, and dev installs can coexist without colliding
         # on `xdg-mime` / Launch Services routing. Pick the scheme this
@@ -1081,7 +1121,7 @@ async def social_callback(
         # build for the matching channel is the only thing that can open
         # this URL.
         deep_link_scheme = _desktop_url_scheme()
-    elif state.startswith("mobile."):
+    elif native_kind == "mobile":
         # Mobile bundles ship one scheme per binary (``clawbits`` only).
         # Env separation comes from the API base URL the client points
         # at, not from the scheme — so we always hand back the bare
@@ -1089,9 +1129,15 @@ async def social_callback(
         deep_link_scheme = "clawbits"
 
     if deep_link_scheme is not None:
+        # Echo the client's nonce so it can bind this callback to the
+        # login it started. Absent for clients that didn't send one —
+        # they get the pre-nonce URL shape and keep working.
+        params = {"token": sealed}
+        if client_state:
+            params["state"] = client_state
         deep_link = (
             f"{deep_link_scheme}://oauth-callback?"
-            + urllib.parse.urlencode({"token": sealed})
+            + urllib.parse.urlencode(params)
         )
         html = f"""<!DOCTYPE html>
 <html lang="en">

--- a/frontend/src/components/OAuthButtons.tsx
+++ b/frontend/src/components/OAuthButtons.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { socialAuthUrl, type OAuthProvider } from "@/lib/api";
-import { isDesktop } from "@/lib/desktop";
+import { beginDesktopOAuth, isDesktop } from "@/lib/desktop";
 import { useSearchParams } from "react-router-dom";
 import { NEXT_PARAM, safeReturnPath } from "@/lib/returnPath";
 
@@ -40,8 +40,14 @@ export default function OAuthButtons({ label }: { label: string }) {
       // backend's `?desktop=1` marker causes the final callback to redirect
       // into `clawbits://oauth-callback?token=…`, which is captured by the
       // deep-link listener in desktop.ts.
+      //
+      // `client_state` is a nonce the backend round-trips back to us in
+      // that deep link. Without it the listener has no way to tell our
+      // own callback from one any web page can fire at the scheme
+      // handler, so it refuses tokens that don't echo it.
       const apiBase = (import.meta.env.VITE_CLAWBITS_API_URL as string | undefined) || window.location.origin;
-      const fullUrl = `${apiBase}${path}?desktop=1`;
+      const clientState = beginDesktopOAuth();
+      const fullUrl = `${apiBase}${path}?desktop=1&client_state=${encodeURIComponent(clientState)}`;
       try {
         const { open } = await import("@tauri-apps/plugin-shell");
         await open(fullUrl);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -13,6 +13,7 @@ import {
   verifySocialEmail,
 } from "../lib/api";
 import { queryKeys } from "../lib/queryKeys";
+import { setDesktopSessionLive } from "../lib/desktop";
 
 const ACTIVE_ORG_KEY = "fc_active_org_id";
 
@@ -127,6 +128,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Mount-only. ``queryClient`` is a stable singleton; the boot org is read
     // from localStorage inside the effect so an org switch never re-runs it.
   }, [queryClient]);
+
+  // Keep the desktop deep-link handler in step with the session: while a
+  // user is signed in it refuses a `clawbits://oauth-callback` token
+  // hand-off, so an OS-routed URL can't silently move the app into
+  // someone else's account. Tracked from `user` rather than from the
+  // stored token, which survives its own session and would otherwise
+  // block a legitimate sign-in after expiry.
+  useEffect(() => { setDesktopSessionLive(user !== null); }, [user]);
 
   const setActiveOrgId = (orgId: string) => {
     localStorage.setItem(ACTIVE_ORG_KEY, orgId);

--- a/frontend/src/lib/desktop.test.ts
+++ b/frontend/src/lib/desktop.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The `clawbits://oauth-callback` deep link is an unauthenticated input: the
+ * OS hands it to us from whatever fired the scheme, so a hostile web page can
+ * deliver one with `<iframe src="clawbits://oauth-callback?token=…">`. Since
+ * the stored token becomes the `Authorization: Bearer` on every API call, and
+ * the backend prefers Bearer over the cookie, accepting an unbound token would
+ * silently move the whole app into the attacker's account.
+ *
+ * These tests pin the two gates that stop that.
+ */
+
+const AUTH_TOKEN_KEY = "fc_desktop_auth_token";
+
+/** Handler the module under test registers with Tauri's event bus. */
+let deepLinkHandler: ((event: { payload: string }) => void) | null = null;
+
+/** Stands in for `window.location.replace`, which jsdom leaves unimplemented
+ *  and which the handler calls on a successful hand-off. */
+const locationReplace = vi.fn();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (_name: string, handler: (event: { payload: string }) => void) => {
+    deepLinkHandler = handler;
+    return Promise.resolve(() => undefined);
+  },
+}));
+
+/**
+ * `isDesktop` is computed once at import time from the presence of
+ * `__TAURI_INTERNALS__`, so the flag has to be planted before the module is
+ * pulled in — hence the dynamic import behind a fresh module registry.
+ */
+async function loadDesktopModule() {
+  vi.resetModules();
+  deepLinkHandler = null;
+  (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+  const mod = await import("@/lib/desktop");
+  await mod.setupDeepLinkListener();
+  return mod;
+}
+
+describe("desktop deep-link OAuth callback", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    locationReplace.mockClear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { href: "http://localhost/", replace: locationReplace },
+    });
+  });
+
+  function deliver(url: string) {
+    expect(deepLinkHandler).not.toBeNull();
+    deepLinkHandler?.({ payload: url });
+  }
+
+  function storedToken(): string | null {
+    return window.localStorage.getItem(AUTH_TOKEN_KEY);
+  }
+
+  it("stores the token when the callback echoes a login we started", async () => {
+    const mod = await loadDesktopModule();
+    const nonce = mod.beginDesktopOAuth();
+
+    deliver(`clawbits://oauth-callback?token=good-token&state=${nonce}`);
+
+    expect(storedToken()).toBe("good-token");
+    expect(locationReplace).toHaveBeenCalledWith("/home");
+  });
+
+  it("ignores a token with no state at all", async () => {
+    const mod = await loadDesktopModule();
+    mod.beginDesktopOAuth();
+
+    deliver("clawbits://oauth-callback?token=attacker-session");
+
+    expect(storedToken()).toBeNull();
+    expect(locationReplace).not.toHaveBeenCalled();
+  });
+
+  it("ignores a token whose state does not match the pending nonce", async () => {
+    const mod = await loadDesktopModule();
+    mod.beginDesktopOAuth();
+
+    deliver("clawbits://oauth-callback?token=attacker-session&state=guessed");
+
+    expect(storedToken()).toBeNull();
+  });
+
+  it("ignores a callback that arrives with no login in flight", async () => {
+    await loadDesktopModule();
+
+    deliver("clawbits://oauth-callback?token=attacker-session&state=whatever");
+
+    expect(storedToken()).toBeNull();
+  });
+
+  it("consumes the nonce so the same deep link cannot be replayed", async () => {
+    const mod = await loadDesktopModule();
+    const nonce = mod.beginDesktopOAuth();
+    const url = `clawbits://oauth-callback?token=good-token&state=${nonce}`;
+
+    deliver(url);
+    expect(storedToken()).toBe("good-token");
+
+    window.localStorage.removeItem(AUTH_TOKEN_KEY);
+    deliver(url);
+    expect(storedToken()).toBeNull();
+  });
+
+  it("refuses to swap the session of a signed-in user", async () => {
+    const mod = await loadDesktopModule();
+    const nonce = mod.beginDesktopOAuth();
+    mod.setDesktopSessionLive(true);
+
+    deliver(`clawbits://oauth-callback?token=attacker-session&state=${nonce}`);
+
+    expect(storedToken()).toBeNull();
+  });
+
+  it("still accepts a sign-in after a session expires", async () => {
+    // Regression guard: the stored token is only cleared on an explicit
+    // logout, so it outlives its own session. Gating the deep link on its
+    // presence — rather than on live auth state — would lock a user out of
+    // signing back in.
+    const mod = await loadDesktopModule();
+    window.localStorage.setItem(AUTH_TOKEN_KEY, "stale-expired-token");
+    mod.setDesktopSessionLive(false);
+    const nonce = mod.beginDesktopOAuth();
+
+    deliver(`clawbits://oauth-callback?token=fresh-token&state=${nonce}`);
+
+    expect(storedToken()).toBe("fresh-token");
+  });
+
+  it("ignores a pending nonce older than the server's state window", async () => {
+    const mod = await loadDesktopModule();
+    const nonce = mod.beginDesktopOAuth();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 11 * 60_000);
+    try {
+      deliver(`clawbits://oauth-callback?token=late-token&state=${nonce}`);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(storedToken()).toBeNull();
+  });
+
+  it("ignores deep links on schemes we do not own", async () => {
+    const mod = await loadDesktopModule();
+    const nonce = mod.beginDesktopOAuth();
+
+    deliver(`evil://oauth-callback?token=attacker-session&state=${nonce}`);
+
+    expect(storedToken()).toBeNull();
+  });
+});

--- a/frontend/src/lib/desktop.ts
+++ b/frontend/src/lib/desktop.ts
@@ -61,6 +61,80 @@ function clearStoredAuthToken(): void {
   try { window.localStorage.removeItem(AUTH_TOKEN_KEY); } catch { /* quota */ }
 }
 
+const PENDING_OAUTH_STATE_KEY = "fc_desktop_oauth_state";
+/** Matches the ``max_age=600`` the backend puts on its OAuth state cookie —
+ *  a nonce older than that belongs to a flow the server has already
+ *  forgotten, so accepting it could only ever be a replay. */
+const PENDING_OAUTH_STATE_TTL_MS = 10 * 60_000;
+
+/**
+ * Mint a one-shot nonce for a desktop OAuth login and remember it.
+ *
+ * The system browser, not the app, receives the OAuth callback; the app
+ * learns the outcome from a `clawbits://oauth-callback` URL that *any*
+ * local program can forge — including a web page pointing an iframe at
+ * the scheme handler. The nonce is what distinguishes a real callback
+ * from a forged one: it goes out on the start URL, rides the WorkOS
+ * `state` round trip, and must come back in the deep link.
+ *
+ * Persisted rather than held in memory so the flow survives both a
+ * webview reload and the cold-start case where the OS relaunches the app
+ * to deliver the URL. localStorage is no more exposed than the session
+ * token already stored beside it.
+ */
+export function beginDesktopOAuth(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  const nonce = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  try {
+    window.localStorage.setItem(
+      PENDING_OAUTH_STATE_KEY,
+      JSON.stringify({ nonce, at: Date.now() }),
+    );
+  } catch { /* quota */ }
+  return nonce;
+}
+
+/**
+ * Consume the pending nonce and report whether `state` matches it.
+ *
+ * One shot: the stored nonce is dropped whether or not it matched, so a
+ * deep link can never be replayed and a failed attempt can't be probed
+ * repeatedly against the same secret.
+ */
+function consumePendingOAuthState(state: string | null): boolean {
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(PENDING_OAUTH_STATE_KEY);
+    window.localStorage.removeItem(PENDING_OAUTH_STATE_KEY);
+  } catch { /* quota */ }
+  if (!raw || !state) return false;
+  try {
+    const pending = JSON.parse(raw) as { nonce?: unknown; at?: unknown };
+    if (typeof pending.nonce !== "string" || typeof pending.at !== "number") return false;
+    if (Date.now() - pending.at > PENDING_OAUTH_STATE_TTL_MS) return false;
+    return pending.nonce === state;
+  } catch {
+    return false;
+  }
+}
+
+let sessionIsLive = false;
+
+/**
+ * Mirror of "AuthContext currently has a user", used by the deep-link
+ * handler to refuse a token hand-off mid-session.
+ *
+ * Deliberately NOT derived from `getStoredAuthToken()`: the stored token
+ * is only cleared on an explicit logout, so it outlives its own session.
+ * Gating on its presence would refuse the deep link of a user who is
+ * legitimately signing back in after an expiry — locking them out for
+ * good.
+ */
+export function setDesktopSessionLive(live: boolean): void {
+  sessionIsLive = live;
+}
+
 /**
  * Install a window.fetch wrapper that:
  *  - rewrites relative /api/* to VITE_CLAWBITS_API_URL (built desktop only),
@@ -306,6 +380,16 @@ const KNOWN_DEEP_LINK_PROTOCOLS = new Set([
  * AuthContext re-probes /me with the Bearer header. Listens for the
  * same event the Rust setup() fires in both cold-start (initial-URL)
  * and warm hand-off cases.
+ *
+ * Treat the payload as hostile. The OS routes the scheme to us from
+ * whatever fired it, so an attacker who hosts
+ * `<iframe src="clawbits://oauth-callback?token=…">` can hand this
+ * listener a session they control — and since the stored token becomes
+ * the `Authorization: Bearer` on every API call, and the backend prefers
+ * Bearer over the cookie, the victim would go on working normally inside
+ * the attacker's account. Two things gate the hand-off: the callback
+ * must echo the nonce from a login this install started, and there must
+ * be no live session to displace.
  */
 export async function setupDeepLinkListener(): Promise<void> {
   if (!isDesktop) return;
@@ -318,10 +402,15 @@ export async function setupDeepLinkListener(): Promise<void> {
     if (!KNOWN_DEEP_LINK_PROTOCOLS.has(parsed.protocol)) return;
     if (parsed.host === "oauth-callback") {
       const token = parsed.searchParams.get("token");
-      if (token) {
-        setStoredAuthToken(token);
-        window.location.replace("/home");
-      }
+      if (!token) return;
+      // Never swap the session out from under a signed-in user. Mirrors
+      // the mobile handler's `status === 'authenticated'` early return in
+      // apps/mobile/src/app/_layout.tsx.
+      if (sessionIsLive) return;
+      // Bind the callback to a login this install actually started.
+      if (!consumePendingOAuthState(parsed.searchParams.get("state"))) return;
+      setStoredAuthToken(token);
+      window.location.replace("/home");
     }
   });
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -58,6 +58,18 @@ http {
         ssl_session_cache   shared:SSL:10m;
         ssl_session_timeout 1d;
 
+        # The debug trace surface is development-only and is gated in the app
+        # as well (see clawbits/fastapi/trace_endpoints.py). Belt-and-braces at
+        # the edge so a deploy with a misconfigured CLAWBITS_ENV still can't
+        # expose it. JSON body so a probe sees the same content-type as any
+        # other API 404 — the app's own envelope carries extra fields nginx
+        # can't reproduce without risking malformed JSON on a quoted $uri.
+        # Deliberately NOT in nginx.dev.conf — dev needs the surface.
+        location ^~ /api/trace/ {
+            default_type application/json;
+            return 404 '{"detail":"Not Found"}';
+        }
+
         location /api/ {
             # Variable forces per-request DNS re-resolution (see resolver above).
             set                $app_target app:8000;

--- a/tests/fastapi/test_trace_endpoints.py
+++ b/tests/fastapi/test_trace_endpoints.py
@@ -1,0 +1,174 @@
+"""Route-level tests for the debug tracer: the dev-only 404 gate, the
+malformed-body leak, and the in-process middleware write path.
+
+Two of these pin decisions that are easy to undo by accident:
+
+* ``test_malformed_body_404s_not_422`` pins ``ingest_spans``' raw-``Request``
+  signature. FastAPI decodes a declared ``Body(...)`` *before* router
+  dependencies run, so re-declaring one would answer 422 in production and
+  re-open the enumeration signal the 404 contract exists to remove.
+* ``test_middleware_write_is_gated`` pins the gate's *location*. The audit
+  suggested an ``if`` around ``include_router``; that would leave this path —
+  ``clawbits_server.request_duration_middleware`` pushing in-process — wide open.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clawbits.fastapi import trace_store
+
+TRACE_ROUTES = [
+    ("GET", "/trace"),
+    ("GET", "/api/trace/traces"),
+    ("GET", "/api/trace/traces/some-id"),
+    ("POST", "/api/trace/spans"),
+]
+
+# Anything that is not in the dev allow-list, including the fail-closed cases.
+NON_DEV_ENVS = [None, "", "production", "staging"]
+
+
+def _set_env(monkeypatch, env: str | None) -> None:
+    if env is None:
+        monkeypatch.delenv("CLAWBITS_ENV", raising=False)
+    else:
+        monkeypatch.setenv("CLAWBITS_ENV", env)
+
+
+@pytest.fixture(autouse=True)
+def _empty_ring():
+    trace_store.clear()
+    yield
+    trace_store.clear()
+
+
+# ---------------------------------------------------------------------------
+# Gated off outside development
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", NON_DEV_ENVS)
+@pytest.mark.parametrize(("method", "path"), TRACE_ROUTES)
+def test_routes_404_outside_dev(test_client: TestClient, monkeypatch, env, method, path):
+    _set_env(monkeypatch, env)
+    resp = test_client.request(method, path, json={"trace_id": "t"} if method == "POST" else None)
+    assert resp.status_code == 404
+    # main.py's global HTTPException handler reshapes the body; "Not Found" is
+    # the same detail an absent route produces, which is the point.
+    assert resp.json()["detail"] == "Not Found"
+
+
+@pytest.mark.parametrize("env", NON_DEV_ENVS)
+def test_malformed_body_404s_not_422(test_client: TestClient, monkeypatch, env):
+    """A declared ``Body(...)`` would leak a 422 straight through the gate."""
+    _set_env(monkeypatch, env)
+    resp = test_client.post(
+        "/api/trace/spans",
+        content=b"{",
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Not Found"
+
+
+# ---------------------------------------------------------------------------
+# Live in development
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_in_dev(test_client: TestClient, monkeypatch):
+    _set_env(monkeypatch, "development")
+    trace_id = f"tr_{uuid.uuid4()}"
+    span = {
+        "trace_id": trace_id,
+        "span": "frontend.send_post",
+        "subsystem": "frontend",
+        "t_start_ms": 1000,
+        "t_end_ms": 1040,
+        "dur_ms": 40,
+    }
+
+    assert test_client.post("/api/trace/spans", json=span).json() == {"accepted": 1}
+
+    listed = test_client.get("/api/trace/traces").json()["traces"]
+    assert [t["trace_id"] for t in listed] == [trace_id]
+    assert listed[0]["subsystems"] == ["frontend"]
+
+    detail = test_client.get(f"/api/trace/traces/{trace_id}").json()
+    assert detail["total_ms"] == 40
+    assert detail["spans"][0]["span"] == "frontend.send_post"
+
+
+def test_viewer_page_served_in_dev(test_client: TestClient, monkeypatch):
+    _set_env(monkeypatch, "development")
+    resp = test_client.get("/trace")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert "trace viewer" in resp.text
+
+
+def test_a_list_payload_is_accepted(test_client: TestClient, monkeypatch):
+    _set_env(monkeypatch, "development")
+    body = [{"trace_id": "a", "span": "x"}, {"trace_id": "b", "span": "y"}, "not-a-dict"]
+    assert test_client.post("/api/trace/spans", json=body).json() == {"accepted": 2}
+
+
+def test_malformed_body_is_accepted_quietly_in_dev(test_client: TestClient, monkeypatch):
+    """Tracing is best-effort: a bad payload must never 4xx an emitter."""
+    _set_env(monkeypatch, "development")
+    resp = test_client.post(
+        "/api/trace/spans",
+        content=b"{",
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"accepted": 0}
+
+
+def test_missing_trace_404_is_distinguishable_from_the_gate(test_client: TestClient, monkeypatch):
+    """The store's own miss and the gate's refusal must not look alike."""
+    _set_env(monkeypatch, "development")
+    resp = test_client.get("/api/trace/traces/tr_absent")
+    assert resp.status_code == 404
+    # The store answers with its own JSONResponse, so it never reaches the
+    # global HTTPException handler and stays distinguishable from the gate's.
+    assert resp.json() == {"error": "not found", "trace_id": "tr_absent"}
+
+
+# ---------------------------------------------------------------------------
+# The in-process middleware write — the path an include_router gate would miss
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", NON_DEV_ENVS)
+def test_middleware_write_is_gated(test_client: TestClient, monkeypatch, env):
+    _set_env(monkeypatch, env)
+    trace_id = f"tr_{uuid.uuid4()}"
+    test_client.get("/api/status", headers={"x-clawbits-trace-id": trace_id})
+    assert trace_store.get_trace(trace_id) is None
+
+
+def test_middleware_records_server_span_in_dev(test_client: TestClient, monkeypatch):
+    _set_env(monkeypatch, "development")
+    trace_id = f"tr_{uuid.uuid4()}"
+    test_client.get("/api/status", headers={"x-clawbits-trace-id": trace_id})
+
+    trace = trace_store.get_trace(trace_id)
+    assert trace is not None
+    span = trace["spans"][0]
+    assert span["span"] == "server.http"
+    assert span["subsystem"] == "server"
+    assert span["path"] == "/api/status"
+
+
+@pytest.mark.parametrize("header", ["x" * 5000, "tr_<img src=x>", "tr id", ""])
+def test_malformed_trace_header_is_ignored(test_client: TestClient, monkeypatch, header):
+    """The header also feeds the ungated ``TRACE`` log line, so validate it at
+    the read site rather than relying on the store's own drop."""
+    _set_env(monkeypatch, "development")
+    resp = test_client.get("/api/status", headers={"x-clawbits-trace-id": header})
+    assert resp.status_code == 200
+    assert trace_store.list_traces() == []

--- a/tests/fastapi/test_trace_store.py
+++ b/tests/fastapi/test_trace_store.py
@@ -1,0 +1,185 @@
+"""Unit tests for the debug tracer's ring buffer — the dev-only gate and the
+span sanitiser.
+
+The gate lives in ``add_span`` rather than around the router because that is the
+only choke point both writers share: the HTTP sink in ``trace_endpoints`` and
+the in-process push from ``clawbits_server.request_duration_middleware``. See
+``test_trace_endpoints`` for the middleware half of that proof.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from clawbits.domain import DEV_ENVS
+from clawbits.fastapi import trace_store
+
+
+def _set_env(monkeypatch, env: str | None) -> None:
+    """Set or unset ``CLAWBITS_ENV``. ``None`` deletes it."""
+    if env is None:
+        monkeypatch.delenv("CLAWBITS_ENV", raising=False)
+    else:
+        monkeypatch.setenv("CLAWBITS_ENV", env)
+
+
+@pytest.fixture(autouse=True)
+def _empty_ring():
+    trace_store.clear()
+    yield
+    trace_store.clear()
+
+
+# ---------------------------------------------------------------------------
+# Gate truth table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", [None, "", "   ", "production", "staging", "prod"])
+def test_add_span_noops_outside_dev(monkeypatch, env):
+    """Fail-closed: unset, empty and unknown environments are NOT dev."""
+    _set_env(monkeypatch, env)
+    assert trace_store.is_trace_enabled() is False
+    trace_store.add_span({"trace_id": "t", "span": "s", "subsystem": "server"})
+    assert trace_store.list_traces() == []
+
+
+@pytest.mark.parametrize("env", sorted(DEV_ENVS))
+def test_add_span_records_in_dev(monkeypatch, env):
+    _set_env(monkeypatch, env)
+    assert trace_store.is_trace_enabled() is True
+    trace_store.add_span({"trace_id": "t", "span": "s", "subsystem": "server"})
+    assert [t["trace_id"] for t in trace_store.list_traces()] == ["t"]
+
+
+def test_gate_ignores_case_and_surrounding_space(monkeypatch):
+    _set_env(monkeypatch, "  Development  ")
+    assert trace_store.is_trace_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# trace_id validation — it is the ring key, so bad ids are dropped, not fixed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "trace_id",
+    [None, 123, "", [], {}, "a" * 65, "tr_<img src=x>", "ok id", "tr_\n", "tr_é"],
+)
+def test_invalid_trace_id_drops_span(monkeypatch, trace_id):
+    _set_env(monkeypatch, "development")
+    trace_store.add_span({"trace_id": trace_id, "span": "s"})
+    assert trace_store.list_traces() == []
+    assert trace_store.is_valid_trace_id(trace_id) is False
+
+
+@pytest.mark.parametrize("trace_id", ["a", "a" * 64, "tr_" + str(uuid.uuid4()), "a.b:c-d_e"])
+def test_valid_trace_id_kept(monkeypatch, trace_id):
+    _set_env(monkeypatch, "development")
+    assert trace_store.is_valid_trace_id(trace_id) is True
+    trace_store.add_span({"trace_id": trace_id, "span": "s"})
+    assert trace_store.get_trace(trace_id) is not None
+
+
+def test_trace_id_is_never_truncated(monkeypatch):
+    """Truncating the ring key would silently merge distinct traces."""
+    _set_env(monkeypatch, "development")
+    long_id = "a" * 64
+    trace_store.add_span({"trace_id": long_id + "b", "span": "s"})
+    assert trace_store.get_trace(long_id) is None
+
+
+# ---------------------------------------------------------------------------
+# Sanitisation — normalise or truncate, never drop a legitimate span
+# ---------------------------------------------------------------------------
+
+
+def _one_span(**extra):
+    trace_store.add_span({"trace_id": "t", **extra})
+    trace = trace_store.get_trace("t")
+    assert trace is not None
+    return trace["spans"][0]
+
+
+@pytest.mark.parametrize("sub", ["frontend", "server", "plugin"])
+def test_known_subsystem_preserved(monkeypatch, sub):
+    _set_env(monkeypatch, "development")
+    assert _one_span(subsystem=sub)["subsystem"] == sub
+
+
+@pytest.mark.parametrize(
+    "sub",
+    [
+        "toString",       # inherited-key probe against the viewer's barColor
+        "constructor",
+        "clawbits-fetch",  # a real-looking but wrong value
+        "<img src=x>",
+        123,
+        None,
+        [],                # unhashable: a bare `in frozenset` would raise TypeError
+        {},
+    ],
+)
+def test_unknown_subsystem_buckets_to_other(monkeypatch, sub):
+    """The span is kept — the viewer already renders an 'other' bucket."""
+    _set_env(monkeypatch, "development")
+    assert _one_span(subsystem=sub, span="s")["subsystem"] == "other"
+
+
+def test_span_name_truncated_and_coerced(monkeypatch):
+    _set_env(monkeypatch, "development")
+    assert len(_one_span(span="x" * 500)["span"]) == 128
+    trace_store.clear()
+    assert _one_span(span={"not": "a string"})["span"] == "unknown"
+
+
+def test_extra_attributes_are_bounded(monkeypatch):
+    _set_env(monkeypatch, "development")
+    span = _one_span(
+        span="server.http",
+        subsystem="server",
+        path="/x" * 5000,
+        flag=True,
+        nothing=None,
+        nested={"a": [1, 2]},
+        listy=[1, 2, 3],
+        **{"k" * 65: "over-long key", **{f"extra{i}": i for i in range(40)}},
+    )
+    # 24 keys max, plus t_start_ms back-filled by _normalize afterwards.
+    assert len(span) <= 25
+    # Core keys are written first, so they always survive the cap.
+    for key in ("trace_id", "span", "subsystem"):
+        assert key in span
+    assert len(span["path"]) == 256
+    assert span["flag"] is True
+    assert span["nothing"] is None
+    # Containers are dropped: a per-string cap would leave these unbounded.
+    assert "nested" not in span
+    assert "listy" not in span
+    assert "k" * 65 not in span
+
+
+def test_normalize_still_backfills_start(monkeypatch):
+    _set_env(monkeypatch, "development")
+    span = _one_span(span="server.http", subsystem="server", t_end_ms=1000, dur_ms=40)
+    assert span["t_start_ms"] == 960
+
+
+@pytest.mark.parametrize("bad", ["soon", [1], {"a": 1}, None, True])
+def test_non_numeric_timings_dropped(monkeypatch, bad):
+    """``_trace_bounds`` and the waterfall sort assume these are numeric when
+    present, and the viewer would render a string as "NaNs"."""
+    _set_env(monkeypatch, "development")
+    span = _one_span(span="s", t_end_ms=bad, dur_ms=bad, t_start_ms=bad)
+    assert "t_end_ms" not in span
+    assert "dur_ms" not in span
+    assert "t_start_ms" not in span
+    assert trace_store.get_trace("t")["total_ms"] is None
+
+
+def test_numeric_timings_kept(monkeypatch):
+    _set_env(monkeypatch, "development")
+    span = _one_span(span="s", t_start_ms=10, t_end_ms=30.5, dur_ms=20.5)
+    assert (span["t_start_ms"], span["t_end_ms"], span["dur_ms"]) == (10, 30.5, 20.5)
+    assert trace_store.get_trace("t")["total_ms"] == 20.5

--- a/tests/fastapi/test_workos_social.py
+++ b/tests/fastapi/test_workos_social.py
@@ -97,6 +97,89 @@ def test_social_callback_mobile_bridge_emits_clawbits_deeplink(test_client):
 
 
 # --------------------------------------------------------------------------
+# Native-client nonce (``client_state``). The desktop app can't see the OAuth
+# state cookie — that lives in the system browser — so it mints its own nonce
+# and requires the deep link to echo it. Without that binding, any web page
+# firing ``clawbits://oauth-callback?token=<attacker session>`` at the OS
+# scheme handler could hand the app a session the attacker controls.
+# --------------------------------------------------------------------------
+
+
+def _desktop_start(test_client, **params):
+    return test_client.get(
+        "/api/auth/social/google/start",
+        params={"desktop": 1, **params},
+        follow_redirects=False,
+    )
+
+
+def test_social_start_embeds_client_state_in_oauth_state(test_client):
+    """The nonce rides inside ``state`` so it inherits the existing
+    state-vs-cookie equality check on callback."""
+    nonce = "a" * 32
+    resp = _desktop_start(test_client, client_state=nonce)
+    assert resp.status_code == 302
+    state = parse_qs(urlparse(resp.headers["location"]).query)["state"][0]
+    assert state.startswith(f"desktop.{nonce}."), state
+
+
+def test_social_start_rejects_malformed_client_state(test_client):
+    """A nonce we can't round-trip is a 400, not a silently dropped binding —
+    a dropped binding is a silently downgraded login."""
+    for bad in ("short", "has.a.dot" + "x" * 20, "bad!chars" + "x" * 20, "z" * 65):
+        resp = _desktop_start(test_client, client_state=bad)
+        assert resp.status_code == 400, (bad, resp.status_code)
+
+
+def test_social_callback_echoes_client_state_into_deep_link(test_client):
+    """The deep link carries the nonce back so the desktop listener can tell
+    this callback apart from one any web page could fire."""
+    nonce = "b" * 32
+    start = _desktop_start(test_client, client_state=nonce)
+    state = parse_qs(urlparse(start.headers["location"]).query)["state"][0]
+    adapter = test_client.app.state.workos
+    code = adapter.inject_social_code(email="desktop@test.com")
+
+    cb = test_client.get(
+        "/api/auth/social/callback",
+        params={"code": code, "state": state},
+        follow_redirects=False,
+    )
+    assert cb.status_code == 200
+    assert "://oauth-callback?token=" in cb.text
+    assert f"state={nonce}" in cb.text
+
+
+def test_social_callback_desktop_without_client_state_still_works(test_client):
+    """Pre-nonce desktop builds keep working against a nonce-aware backend:
+    they send no ``client_state`` and get the old URL shape back."""
+    start = _desktop_start(test_client)
+    state = parse_qs(urlparse(start.headers["location"]).query)["state"][0]
+    adapter = test_client.app.state.workos
+    code = adapter.inject_social_code(email="olddesktop@test.com")
+
+    cb = test_client.get(
+        "/api/auth/social/callback",
+        params={"code": code, "state": state},
+        follow_redirects=False,
+    )
+    assert cb.status_code == 200
+    assert "://oauth-callback?token=" in cb.text
+    assert "state=" not in cb.text
+
+
+def test_split_native_state_accepts_pre_nonce_layout():
+    """A flow started before a deploy must still resolve its scheme after it,
+    so the two-segment ``<kind>.<random>`` layout stays readable."""
+    from clawbits.fastapi.workos_auth import _split_native_state
+
+    assert _split_native_state("desktop.abc123") == ("desktop", "")
+    assert _split_native_state("desktop.NONCE.abc123") == ("desktop", "NONCE")
+    assert _split_native_state("mobile..abc123") == ("mobile", "")
+    assert _split_native_state("plainwebstate") == (None, "")
+
+
+# --------------------------------------------------------------------------
 # Email verification gate (WorkOS raises EmailVerificationRequiredError when
 # linking a new IdP to an email it doesn't yet trust).
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What and why

Hardens desktop social login against deep-link session injection: a hostile page
could fire `clawbits://oauth-callback?token=…` (e.g. via an iframe) and silently
log the app into an attacker's account. The desktop client now mints a one-shot
nonce that rides the WorkOS `state` round trip and must be echoed back in the
deep link; the listener also refuses hand-offs while a session is live, after a
10-minute window, or on unknown schemes. Alongside it, the unauthenticated
`/api/trace/*` + `/trace` debug surface (cross-user activity timeline, endpoint
map, XSS-able viewer) is now dev-env-only — gated fail-closed in the store and
router (404, no enumeration signal), input-sanitised, escaped in the viewer,
and blocked at the nginx edge as belt-and-braces.

## How to verify

Backend (state layout, nonce echo, trace gating/sanitisation):

    pytest tests/fastapi/test_workos_social.py tests/fastapi/test_trace_endpoints.py tests/fastapi/test_trace_store.py

Frontend (deep-link listener gates):

    cd frontend && npm test -- run src/lib/desktop.test.ts

Click-through: in a dev desktop build, sign in with Google/GitHub and confirm
the browser hand-off still lands you in `/home`. Then, signed out, open
`clawbits://oauth-callback?token=junk` by hand — the app must ignore it.
With `CLAWBITS_ENV=production`, `GET /api/trace/traces` and `/trace` must 404.