### PR TITLE
fix agent removal

### DIFF
--- a/clawbits/db/table_write.py
+++ b/clawbits/db/table_write.py
@@ -908,6 +908,19 @@ class TableWrite:
             delete(AgentUsageDaily).where(AgentUsageDaily.agent_id == agent_id)
         )
 
+        # The skills sync plane (mirrored installs + the per-agent sync state
+        # every self-report writes) FKs the agent with no cascade either. Like
+        # automations and usage it's control-plane state rather than authored
+        # content, so both delete paths drop it -- and because the sync-state
+        # row exists for every agent whose plugin ever reported, leaving it
+        # behind makes essentially every agent undeletable.
+        session.exec(
+            delete(AgentSkillInstall).where(AgentSkillInstall.agent_id == agent_id)
+        )
+        session.exec(
+            delete(AgentSkillSyncState).where(AgentSkillSyncState.agent_id == agent_id)
+        )
+
         if keep_content:
             TableWrite._delete_agent_keep_content(session, agent)
             return departures
@@ -1445,6 +1458,30 @@ class TableWrite:
             .where(AgentSignupRequest.reviewed_by == human_id)
             .values(reviewed_by=None)
         )
+        # Same treatment for everything else that only *names* the user as the
+        # person who authored/published/installed/created it. These are all
+        # plain NO ACTION FKs, so an uncleared one blocks the user delete; the
+        # rows themselves belong to an org that outlives the account (a skill
+        # in a shared library, an automation on someone else's agent), so they
+        # survive with attribution dropped rather than being deleted.
+        session.exec(
+            update(Skill).where(Skill.created_by == human_id).values(created_by=None)
+        )
+        session.exec(
+            update(SkillVersion)
+            .where(SkillVersion.published_by == human_id)
+            .values(published_by=None)
+        )
+        session.exec(
+            update(AgentSkillInstall)
+            .where(AgentSkillInstall.installed_by == human_id)
+            .values(installed_by=None)
+        )
+        session.exec(
+            update(Automation)
+            .where(Automation.created_by == human_id)
+            .values(created_by=None)
+        )
         # Sidebar preview attribution for channels where the user authored the
         # last message — recompute below once their posts are gone.
         preview_channel_ids = list(session.exec(
@@ -1507,8 +1544,45 @@ class TableWrite:
             session.exec(
                 delete(Repository).where(Repository.org_id == org_id)
             )
+            # The org's skill library goes with the org: ``skills.org_id`` is
+            # NOT NULL, so there's nowhere to re-home it to. Order matters —
+            # versions and installs both reference ``skills.skill_id`` with no
+            # cascade, and a fork in a surviving org references the source
+            # skill (the model keeps that FK precisely so deleting the source
+            # never deletes the fork, so null the pointer rather than follow
+            # it).
+            org_skill_ids = list(session.exec(
+                select(Skill.skill_id).where(Skill.org_id == org_id)
+            ).all())
+            if org_skill_ids:
+                session.exec(
+                    update(Skill)
+                    .where(Skill.forked_from_skill_id.in_(org_skill_ids))
+                    .values(forked_from_skill_id=None)
+                )
+                # Defensive, like the agent detach below: an install row is a
+                # mirror of what's on the agent's disk, and the next self-report
+                # re-creates it as an unmanaged ('external') row — there's just
+                # no catalog entry left to manage it from.
+                session.exec(
+                    delete(AgentSkillInstall).where(
+                        AgentSkillInstall.skill_id.in_(org_skill_ids)
+                    )
+                )
+                session.exec(
+                    delete(SkillVersion).where(
+                        SkillVersion.skill_id.in_(org_skill_ids)
+                    )
+                )
+                session.exec(delete(Skill).where(Skill.skill_id.in_(org_skill_ids)))
             # Defensive: detach any agent still tagged to this org (the operate
-            # guard means none should remain operated by this user).
+            # guard means none should remain operated by this user), and with it
+            # the install rows tagged to the org the agent is leaving.
+            session.exec(
+                update(AgentSkillInstall)
+                .where(AgentSkillInstall.org_id == org_id)
+                .values(org_id=None)
+            )
             session.exec(
                 update(Agent).where(Agent.org_id == org_id).values(org_id=None)
             )

--- a/tests/fastapi/test_human_orgs.py
+++ b/tests/fastapi/test_human_orgs.py
@@ -792,3 +792,137 @@ def test_delete_human_user_wipes_content_and_cleans_channels(test_client):
         org = db.get(Organization, "wipe_org")
         assert org is not None
         assert org.created_by == vid
+
+
+def _create_skill(tc: TestClient, token: str, org_id: str, slug: str) -> dict:
+    r = tc.post(
+        f"/api/human/orgs/{org_id}/skills",
+        json={
+            "slug": slug,
+            "display_name": slug,
+            "manifest": {"name": slug, "description": "A skill the account owns."},
+            "body_md": f"# {slug}\n\nDo the thing.\n",
+        },
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_delete_account_with_org_skills(test_client):
+    """A user who authored skills can still delete their account.
+
+    ``skills.created_by`` / ``skill_versions.published_by`` FK ``human_users``
+    with no cascade, and ``skills.org_id`` FKs the personal org that gets torn
+    down with the account — so the library has to be cleared or the delete
+    500s (the same regression class as the agent-delete skills bug).
+    """
+    from sqlmodel import Session, select
+
+    from clawbits.db.models import HumanUser, Organization, Skill, SkillVersion
+
+    reg = _register(test_client, "skill-author@test.com")
+    uid = reg["user"]["id"]
+    org_id = f"user-{uid}"
+
+    skill = _create_skill(test_client, reg["access_token"], org_id, "owned-skill")
+    # A second version, so the skill has more than the auto-published v1.
+    r = test_client.post(
+        f"/api/human/orgs/{org_id}/skills/{skill['skill_id']}/versions",
+        json={
+            "manifest": {"name": "owned-skill", "description": "Now sharper."},
+            "body_md": "# v2\n\nSharper.\n",
+        },
+        headers=_auth(reg["access_token"]),
+    )
+    assert r.status_code == 200, r.text
+
+    r = test_client.delete("/api/human/account", headers=_auth(reg["access_token"]))
+    assert r.status_code == 204, r.text
+
+    with Session(test_client.app._engine) as db:
+        assert db.get(HumanUser, uid) is None
+        assert db.get(Organization, org_id) is None
+        assert db.exec(select(Skill).where(Skill.org_id == org_id)).all() == []
+        assert db.exec(
+            select(SkillVersion).where(SkillVersion.skill_id == skill["skill_id"])
+        ).all() == []
+
+
+def test_delete_account_keeps_skills_in_surviving_org(test_client):
+    """A skill the user authored in an org that outlives them survives with
+    its attribution cleared, rather than being deleted with the account."""
+    from datetime import UTC, datetime
+
+    from sqlmodel import Session
+
+    from clawbits.db.models import HumanUser, Organization, OrgMember, Skill
+
+    owner = _register(test_client, "lib-owner@test.com")
+    author = _register(test_client, "lib-author@test.com")
+    now = datetime.now(UTC)
+    with Session(test_client.app._engine) as db:
+        db.add(Organization(
+            org_id="lib_org", workos_org_id="wos_lib", name="lib-org",
+            created_by=owner["user"]["id"], created_at=now,
+        ))
+        db.flush()
+        db.add(OrgMember(org_id="lib_org", human_id=owner["user"]["id"], role="owner"))
+        db.add(OrgMember(org_id="lib_org", human_id=author["user"]["id"], role="member"))
+        db.commit()
+
+    skill = _create_skill(test_client, author["access_token"], "lib_org", "shared-skill")
+
+    r = test_client.delete("/api/human/account", headers=_auth(author["access_token"]))
+    assert r.status_code == 204, r.text
+
+    with Session(test_client.app._engine) as db:
+        assert db.get(HumanUser, author["user"]["id"]) is None
+        row = db.get(Skill, skill["skill_id"])
+        assert row is not None
+        assert row.created_by is None
+
+
+def test_delete_account_with_skill_installs_and_automations(test_client):
+    """Rows that merely *name* the user — an install they triggered on someone
+    else's agent, an automation they created — keep the agent's control-plane
+    state intact and lose only the attribution."""
+    from sqlmodel import Session
+
+    from clawbits.db.models import (
+        Agent,
+        AgentSkillInstall,
+        Automation,
+        HumanUser,
+    )
+
+    operator = _register(test_client, "auto-operator@test.com")
+    actor = _register(test_client, "auto-actor@test.com")
+    actor_id = actor["user"]["id"]
+
+    with Session(test_client.app._engine) as db:
+        db.add(Agent(
+            agent_id="shared_agent", api_key_hash="sa_h", eth_private_key="sa_k",
+            nickname="Shared", operator_id=operator["user"]["id"],
+            require_response_approval=True,
+        ))
+        db.flush()
+        db.add(AgentSkillInstall(
+            install_id="inst_1", agent_id="shared_agent", slug="triage",
+            installed_by=actor_id,
+        ))
+        db.add(Automation(
+            automation_id="auto_1", agent_id="shared_agent",
+            desired_spec={"schedule": "0 9 * * *"}, created_by=actor_id,
+        ))
+        db.commit()
+
+    r = test_client.delete("/api/human/account", headers=_auth(actor["access_token"]))
+    assert r.status_code == 204, r.text
+
+    with Session(test_client.app._engine) as db:
+        assert db.get(HumanUser, actor_id) is None
+        install = db.get(AgentSkillInstall, "inst_1")
+        assert install is not None and install.installed_by is None
+        automation = db.get(Automation, "auto_1")
+        assert automation is not None and automation.created_by is None

--- a/tests/fastapi/test_skills_sync.py
+++ b/tests/fastapi/test_skills_sync.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
-from clawbits.db.models import Agent
+from clawbits.db.models import Agent, AgentSkillInstall, AgentSkillSyncState
 from tests.fastapi._auth_helpers import login_human, personal_org_id
 from tests.fastapi.conftest import _create_agent
 
@@ -439,3 +439,75 @@ def test_library_reports_confirmed_installs_separately_from_pending(test_client:
     )
     row = library_row()
     assert (row["installed_agent_count"], row["pending_agent_count"]) == (0, 1)
+
+
+def test_delete_agent_with_skill_rows(test_client: TestClient, _test_engine):
+    """Deleting an agent that reported skills must not FK-error.
+
+    ``agent_skill_installs.agent_id`` and ``agent_skill_sync_state.agent_id``
+    both FK ``agents`` with no ON DELETE cascade, so the delete has to clear
+    them or the whole thing 500s. The sync-state row is written by *every*
+    self-report, so without this every agent whose plugin ever reported is
+    undeletable. Same class of regression as automations and usage.
+    """
+    agent_id, api_key, token, org_id = _setup(test_client, "skill-del@clawbits.ai")
+
+    r = test_client.post(
+        "/api/agentic/skills/state",
+        json=_report([
+            {
+                "slug": "doomed",
+                "root": "/home/node/.openclaw/workspace/skills",
+                "manifest": {"name": "doomed", "description": "Goes with the agent."},
+            }
+        ]),
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = test_client.delete(
+        f"/api/human/orgs/{org_id}/agents/{agent_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["deleted"] is True
+
+    with Session(_test_engine) as db:
+        assert db.get(Agent, agent_id) is None
+        assert db.get(AgentSkillSyncState, agent_id) is None
+        assert db.exec(
+            select(AgentSkillInstall).where(AgentSkillInstall.agent_id == agent_id)
+        ).all() == []
+
+
+def test_delete_agent_keep_content_with_skill_rows(
+    test_client: TestClient, _test_engine
+):
+    """The keep-content path drops the same rows: skills are the agent's own
+    control-plane state, not authored content to re-home onto the placeholder.
+    """
+    agent_id, api_key, token, org_id = _setup(test_client, "skill-del-keep@clawbits.ai")
+    test_client.post(
+        "/api/agentic/skills/state",
+        json=_report([
+            {
+                "slug": "doomed-too",
+                "root": "/home/node/.openclaw/workspace/skills",
+                "manifest": {"name": "doomed-too", "description": "Also goes."},
+            }
+        ]),
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+
+    r = test_client.delete(
+        f"/api/human/orgs/{org_id}/agents/{agent_id}?keep_content=true",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+
+    with Session(_test_engine) as db:
+        assert db.get(Agent, agent_id) is None
+        assert db.get(AgentSkillSyncState, agent_id) is None
+        assert db.exec(
+            select(AgentSkillInstall).where(AgentSkillInstall.agent_id == agent_id)
+        ).all() == []


### PR DESCRIPTION
This pull request addresses several issues related to deleting agents and human users, particularly focusing on cleaning up related "skills" and attribution rows to avoid foreign key errors and ensure referential integrity. The changes ensure that deleting an agent or a user does not leave behind orphaned rows or block deletions due to foreign key constraints. Comprehensive tests have also been added to cover these scenarios and prevent regressions.

**Database deletion logic improvements:**

* When deleting an agent, the code now also deletes related `AgentSkillInstall` and `AgentSkillSyncState` rows to prevent foreign key errors and ensure the agent can be deleted even if it has reported skills in the past.
* When deleting a human user, any rows that reference the user only for attribution—such as `Skill.created_by`, `SkillVersion.published_by`, `AgentSkillInstall.installed_by`, and `Automation.created_by`—are now updated to set those fields to `None` instead of blocking the deletion.
* When deleting an organization (as part of account deletion), the code now clears or deletes all related skills, their versions, and associated installs, and also detaches agents and their skill installs from the org to avoid foreign key issues.

**Testing and regression coverage:**

* New tests in `test_human_orgs.py` verify that deleting a user with authored skills, skill installs, or automations works as intended, and that attribution is cleared where appropriate while control-plane state remains intact.
* New tests in `test_skills_sync.py` ensure that deleting an agent with related skill rows (including the "keep content" path) does not result in foreign key errors and that all related rows are properly cleaned up.

**Test infrastructure improvements:**

* Test imports were updated to include all necessary models and SQL select helpers for the new test cases.