### PR TITLE
fix url in web notifications

### DIFF
--- a/clawbits/domain.py
+++ b/clawbits/domain.py
@@ -7,6 +7,8 @@ shared infra for development).
 Domains
 -------
 - ``BASE_DOMAIN``       – top-level domain (``freeclaws.ai`` or ``clawbits.ai``)
+- ``APP_DOMAIN``        – the web app host (``app.<BASE_DOMAIN>``)
+- ``APP_URL``           – origin of the web app (``https://<APP_DOMAIN>``)
 - ``SHARE_DOMAIN``      – R2 public file hosting (``share.<BASE_DOMAIN>``)
 - ``EMAIL_DOMAIN``      – agent email addresses (``<agent>@<BASE_DOMAIN>``)
 - ``SYSTEM_EMAIL``      – system git-commit author email
@@ -26,6 +28,12 @@ IS_PRODUCTION: bool = CLAWBITS_ENV == "production"
 BASE_DOMAIN: str = "clawbits.ai" if IS_PRODUCTION else "freeclaws.ai"
 
 # Sub-domains / derived
+# The web app lives on ``app.<BASE_DOMAIN>``; the apex serves the marketing
+# site and 404s on every app route (see the apex cutover, 2026-08-12). Anything
+# that hands a *user* a link into the app - notably the web-push payload - must
+# build it from here, never from BASE_DOMAIN.
+APP_DOMAIN: str = os.getenv("CLAWBITS_APP_DOMAIN", f"app.{BASE_DOMAIN}")
+APP_URL: str = os.getenv("CLAWBITS_APP_URL", f"https://{APP_DOMAIN}").rstrip("/")
 SHARE_DOMAIN: str = os.getenv("CUSTOM_DOMAIN", f"share.{BASE_DOMAIN}")
 EMAIL_DOMAIN: str = os.getenv("STALWART_EMAIL_DOMAIN", BASE_DOMAIN)
 SYSTEM_EMAIL: str = f"system@{BASE_DOMAIN}"

--- a/clawbits/realtime/web_push.py
+++ b/clawbits/realtime/web_push.py
@@ -29,6 +29,8 @@ import json
 import logging
 import os
 
+from clawbits.domain import APP_URL
+
 log = logging.getLogger(__name__)
 
 # Bound concurrent sends so a fan-out to a large channel doesn't open
@@ -369,7 +371,15 @@ def _build_payload(channel_meta: dict | None, post: dict) -> dict:
         "body": body,
         "author": author,
         "channelId": channel_id,
-        "url": f"/channels/{channel_id}" if channel_id else "/",
+        # ABSOLUTE, on the app origin — never a bare path. A relative URL is
+        # resolved by the service worker against *its own* origin, and browsers
+        # that registered the SW before the apex cutover (2026-08-12, when the
+        # app moved off clawbits.ai) still hold a registration on the apex. Those
+        # clients opened ``clawbits.ai/channels/…``, which the marketing site
+        # 404s. Sending the origin in the payload steers even those stale
+        # registrations to the right host. See ``setupPushClickNavigation``,
+        # which folds a same-origin absolute URL back to a path for soft nav.
+        "url": f"{APP_URL}/channels/{channel_id}" if channel_id else f"{APP_URL}/",
         # Same tag per channel → a newer message replaces the older banner
         # instead of stacking, even if delivery races a streaming finalise.
         "tag": f"channel:{channel_id}",

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -62,11 +62,13 @@ sudo apt-get install -f       # fixes missing libnotify4 etc. if dpkg complained
 Checks worth doing after install:
 
 - **App icon + description** in GNOME Software / app drawer search ("clawbits-staging"): icon matches the channel build, `GenericName` shows "AI Agent Messaging (Staging)", search terms from `Keywords=` work.
-- **Notifications**: trigger one from another account, or via the in-app debug ping (see below). If the icon is missing or notifications don't appear, follow the diagnostic flow in the next section.
+- **Notifications**: **Settings → Notifications → Send a test**, or trigger one from another account. That panel also reports the notification daemon it found and whether a matching `.desktop` file is installed. If the icon is missing or notifications don't appear, follow the diagnostic flow in the next section.
 - **About dialog** (app menu → About clawbits-staging): name, version, icon, comment, website, copyright all populated.
 - **Deep link**: `xdg-open clawbits-staging://oauth-callback?token=foo` (or `clawbits://...` for prod) should focus the running app and trigger the auth flow.
 - **Window chrome**: solid window background (no see-through to desktop), menu bar (Edit/View/Window) has a proper background.
 - **Close hides, app keeps running**: red-X / `Cmd-W` hide the window but the process stays up (`pgrep clawbits-staging` still lists it), so notifications keep arriving. Reopen via the tray's Show, `Ctrl+Shift+C`, GNOME's Background Apps menu, or relaunch.
+- **Clicking a notification** raises the window and lands on the channel the message came from. Needs the daemon to advertise the `actions` capability (Settings → Notifications lists what yours reports); without it the banner still shows, it just isn't clickable. Not yet wired on macOS.
+- **A busy channel doesn't stack banners**: a second message in the same channel replaces the first rather than adding to the tray. Look for `replaces_id=Some(N)` in the log.
 - **Quit fully exits**: the tray's Quit, app-menu Quit (`Ctrl+Q`), or Background Apps → Quit terminate the process (`pgrep clawbits-staging` then returns nothing).
 
 ### Diagnosing Linux notifications
@@ -85,12 +87,8 @@ Reproduction recipe — run after installing the .deb:
    ```bash
    clawbits-staging
    ```
-2. **Open DevTools**: `View → Toggle DevTools`, or `Cmd+Alt+I`. (Built into every channel via the `devtools` Tauri feature, so it works in release/staging too.)
-3. **Either** receive a real chat message **or** fire a hand-crafted ping from the DevTools console — both go through the same code path with full payload logging:
-   ```js
-   await window.__TAURI_INTERNALS__.invoke('notify_debug_ping')
-   ```
-4. **Grab the log** and share it back:
+2. **Either** receive a real chat message **or** press **Send a test** in Settings → Notifications — both go through the same code path with full payload logging. (The same command is still reachable from DevTools, `View → Toggle DevTools` / `Cmd+Alt+I`, as `await window.__TAURI_INTERNALS__.invoke('notify_debug_ping')`.)
+3. **Grab the log** and share it back:
    ```bash
    cat ~/.local/share/ai.clawbits.staging/logs/clawbits.log
    ```
@@ -100,7 +98,8 @@ What to look for in the log:
 - A `--- notification environment ---` block at the top of each run. It dumps `XDG_CURRENT_DESKTOP`, the resolved executable path, every checked `.desktop` file location, whether `notify-send` is installed, and the notification daemon's identity + capabilities.
 - `.desktop check: ... -> FOUND` for at least one path with basename matching `desktop_entry_name`. **If every path says `missing`**, GNOME Shell silently drops our notifications — the install didn't register a `.desktop` file the Shell can match against. The `.deb` registers one system-wide; **AppImage** runs self-register one to `~/.local/share/applications/<slug>.desktop` on first launch — look for `appimage integration: wrote ...` (or `... already current`) in the log. If that line is missing on an AppImage run, `APPIMAGE`/`HOME` weren't set.
 - `notify server: name=... vendor=...` — confirms D-Bus reached a daemon. Missing this line means D-Bus itself is failing (sandbox, no daemon).
-- Per delivery: `notify send (message): ...` lists the exact summary, body, and every hint (icon, category, urgency, sound, timeout). `notify result (...): OK id=N` or `ERR err=...` follows.
+- Per delivery: `notify send (message): ...` lists the exact summary, body, and every hint (icon, category, urgency, sound, timeout), plus the `replaces_id` being reused for that channel. `notify result (...): OK id=N` or `ERR err=...` follows.
+- **The first thing to check, before anything above.** If a message produced no banner and there is *no* `notify send (message):` line for it at all, the shell never tried — the failure is in the frontend gate, not in D-Bus, and nothing else in this section applies. (This is what `isAppInForeground()` in `frontend/src/lib/desktop.ts` exists to get right: the app suppresses notifications while you are looking at it, and it must not mistake a window hidden to the tray for a focused one.)
 
 Cross-checks that quickly localize the failure:
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -63,34 +63,66 @@ fn set_recent_channels(
     Ok(())
 }
 
-/// Post a notification for a new channel message. Each delivery is a
-/// fresh notification with a unique identifier — macOS and Linux both
-/// banner on every new message; macOS additionally groups them per
-/// channel via `threadIdentifier` in Notification Center.
-#[tauri::command]
+/// Post a notification for a new channel message. macOS banners every message
+/// and groups them per channel via `threadIdentifier`; Linux replaces the
+/// channel's previous banner in place.
+///
+/// `async` is load-bearing, not stylistic. Tauri executes non-async commands
+/// **on the main thread**, and the Linux path used to make a blocking D-Bus
+/// call from here — one that can wait out the 25s service-activation timeout
+/// when no notification daemon is running, freezing the window for that long.
+/// Delivery is now queued onto a notifier thread, and `async` keeps this
+/// handler off the UI thread regardless.
+#[tauri::command(async)]
 fn notify_channel_message(
     app: tauri::AppHandle,
     message: notifications::ChannelMessage,
 ) -> Result<(), String> {
-    // NSUserNotification (dev) requires main-thread dispatch;
-    // UNUserNotificationCenter (prod) and D-Bus (Linux) don't strictly
-    // need it, but routing through `run_on_main_thread` keeps the call
-    // site uniform.
-    app.run_on_main_thread(move || {
+    // NSUserNotification (dev) requires main-thread dispatch, so macOS keeps
+    // it. Linux must NOT go anywhere near the main thread — see above.
+    #[cfg(target_os = "macos")]
+    {
+        app.run_on_main_thread(move || {
+            notifications::deliver(&message);
+        })
+        .map_err(|e| e.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
         notifications::deliver(&message);
-    })
-    .map_err(|e| e.to_string())
+        Ok(())
+    }
 }
 
-/// Debug-only: fire a hand-crafted test notification through the same
-/// Linux delivery path as real messages. Used to isolate "is the daemon
-/// dropping our payload, or is it dropping our connection?" without
-/// needing a second account to post a real message. Callable from the
-/// frontend via `invoke('notify_debug_ping')`; on macOS / Windows it
-/// just logs and returns.
-#[tauri::command]
+/// Fire a test notification through the same delivery path as real messages.
+/// Backs the "Send a test notification" button in Settings → Notifications;
+/// isolates "the daemon dropped our payload" from "the app never sent one".
+#[tauri::command(async)]
 fn notify_debug_ping(app: tauri::AppHandle) -> Result<(), String> {
-    app.run_on_main_thread(notifications::debug_ping)
+    #[cfg(target_os = "macos")]
+    {
+        app.run_on_main_thread(notifications::debug_ping)
+            .map_err(|e| e.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        notifications::debug_ping();
+        Ok(())
+    }
+}
+
+/// What this machine can tell us about notification delivery — daemon
+/// identity, capabilities, and whether an installed `.desktop` file matches
+/// the hint we send. Backs the diagnostics panel in Settings → Notifications.
+///
+/// On Linux this waits on the notifier thread, so it runs via `spawn_blocking`
+/// rather than occupying an async worker for the duration.
+#[tauri::command]
+async fn notify_diagnostics() -> Result<notifications::Diagnostics, String> {
+    tauri::async_runtime::spawn_blocking(notifications::diagnostics)
+        .await
         .map_err(|e| e.to_string())
 }
 
@@ -330,6 +362,26 @@ pub fn run() {
                     .clone()
                     .unwrap_or_else(|| binary.clone());
                 notifications::set_app_identity(&binary, &product_name);
+                // Clicking a notification should land the user in the channel
+                // it came from, the same as the web build's service worker
+                // does. The handler runs on the watcher thread that the D-Bus
+                // signal wakes, so the window calls are bounced back onto the
+                // main thread; emitting the event is thread-safe either way.
+                {
+                    use tauri::Emitter;
+                    let handle = app.handle().clone();
+                    notifications::set_activation_handler(move |channel_id| {
+                        let _ = handle.emit("clawbits://notification-activated", channel_id);
+                        let window_handle = handle.clone();
+                        let _ = handle.run_on_main_thread(move || {
+                            if let Some(window) = window_handle.get_webview_window("main") {
+                                let _ = window.unminimize();
+                                let _ = window.show();
+                                let _ = window.set_focus();
+                            }
+                        });
+                    });
+                }
                 // AppImage runs install nothing system-wide, so GNOME has
                 // no `.desktop` to match our notifications' `desktop-entry`
                 // hint against and silently drops them. Write a user-level
@@ -361,6 +413,7 @@ pub fn run() {
             set_recent_channels,
             notify_channel_message,
             notify_debug_ping,
+            notify_diagnostics,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/desktop/src-tauri/src/notifications.rs
+++ b/desktop/src-tauri/src/notifications.rs
@@ -1,11 +1,17 @@
 //! Per-channel desktop notifications.
 //!
-//! Design: every incoming message gets its own fresh notification with
-//! a unique identifier — that way macOS treats each delivery as a new
-//! arrival (banner + sound) instead of as an "update to existing"
-//! (silent, in-place mutation). On macOS we use `threadIdentifier` so
-//! Notification Center still groups them per channel; on Linux we just
-//! let the daemon stack them however it likes.
+//! Design differs per platform because the two systems coalesce differently.
+//! On macOS every delivery is a fresh notification with a unique identifier —
+//! that way the OS treats it as a new arrival (banner + sound) rather than an
+//! "update to existing" (silent, in-place mutation) — and `threadIdentifier`
+//! groups them per channel in Notification Center. On Linux there is no such
+//! grouping, so each channel instead reuses its previous notification id via
+//! `replaces_id`: the newest message supersedes the last banner from that
+//! channel, matching what the web build gets from a per-channel push `tag`.
+//!
+//! Linux delivery is never inline. A dedicated notifier thread owns every
+//! D-Bus call, because those calls block and Tauri runs non-async commands on
+//! the main thread. See the `linux` module for why that mattered.
 //!
 //! Two macOS backends:
 //!
@@ -25,7 +31,39 @@
 #[cfg(target_os = "linux")]
 use std::sync::OnceLock;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+/// What this machine can actually tell us about notification delivery.
+///
+/// Everything here was already gathered at boot and written to the log file,
+/// where only someone who knows to look for it ever saw it. Returning it to
+/// the frontend is what turns "notifications don't work" into a report that
+/// names the daemon and says whether GNOME has a `.desktop` file to attribute
+/// us to. Linux fills every field; macOS has no equivalent surface (the OS
+/// owns permission state) and reports only that it is supported.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostics {
+    /// `"linux"` | `"macos"` | `"other"`.
+    pub platform: String,
+    /// False on platforms with no native backend compiled in (Windows today).
+    pub supported: bool,
+    /// Notification daemon identity — GNOME Shell, Plasma, dunst, mako, …
+    pub server_name: Option<String>,
+    pub server_vendor: Option<String>,
+    /// Daemon capability list, verbatim from `org.freedesktop.Notifications`.
+    pub capabilities: Vec<String>,
+    /// The `DesktopEntry` hint we send, and the installed `.desktop` file
+    /// whose basename matches it. A `None` file with a `Some` hint is the
+    /// single highest-signal failure: GNOME has nothing to attribute us to
+    /// and drops every notification silently.
+    pub desktop_entry: Option<String>,
+    pub desktop_file: Option<String>,
+    /// Path to `notify-send`, when libnotify-bin is installed.
+    pub notify_send: Option<String>,
+    /// Set when the daemon could not be reached at all.
+    pub error: Option<String>,
+}
 
 // Tauri serializes JS payloads via serde_json with default field-name
 // matching, so the Rust struct has to declare the camelCase shape the
@@ -87,9 +125,15 @@ pub fn deliver(message: &ChannelMessage) {
     }
 }
 
+/// Linux delivery never happens inline. Every D-Bus call this module makes is
+/// a blocking round trip, and D-Bus will try to *service-activate* a
+/// notification daemon that isn't running — a wait bounded only by the 25s
+/// activation timeout. Tauri runs non-async commands on the main thread, so an
+/// inline call froze the UI for as long as the daemon took to answer. Handing
+/// the message to the notifier thread returns immediately.
 #[cfg(target_os = "linux")]
 pub fn deliver(message: &ChannelMessage) {
-    linux::deliver(message);
+    linux::enqueue(linux::Job::Message(message.clone()));
 }
 
 /// Linux-only: dump everything relevant to D-Bus notification routing
@@ -97,9 +141,17 @@ pub fn deliver(message: &ChannelMessage) {
 /// name and `DesktopEntry` we'll be sending are known. Call site in
 /// `lib.rs` is gated on `target_os = "linux"`, so no stub is needed
 /// elsewhere.
+///
+/// Queued rather than run inline: the dump probes the daemon over D-Bus, and
+/// doing that from `setup()` blocked the window from appearing at all on a
+/// machine with no daemon running.
 #[cfg(target_os = "linux")]
 pub fn log_linux_environment(binary: &str, product_name: &str, identifier: &str) {
-    linux::log_environment(binary, product_name, identifier);
+    linux::enqueue(linux::Job::LogEnvironment {
+        binary: binary.to_string(),
+        product_name: product_name.to_string(),
+        identifier: identifier.to_string(),
+    });
 }
 
 /// Linux + AppImage only: ensure a user-level `.desktop` file exists so
@@ -109,14 +161,61 @@ pub fn log_linux_environment(binary: &str, product_name: &str, identifier: &str)
 /// send. No-op when the app wasn't launched from an AppImage (`.deb` /
 /// `cargo tauri dev`). Call site in `lib.rs` is gated on `target_os =
 /// "linux"`, so no stub is needed elsewhere.
+///
+/// Also queued — it shells out to `update-desktop-database`, and the notifier
+/// thread is FIFO, so this still lands before the first message notification.
 #[cfg(target_os = "linux")]
 pub fn ensure_appimage_desktop_integration() {
-    linux::ensure_appimage_desktop_file();
+    linux::enqueue(linux::Job::AppImageIntegration);
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 pub fn deliver(_message: &ChannelMessage) {
     // Windows / unsupported — fall through.
+}
+
+/// Report what this machine can tell us about notification delivery. Backs the
+/// diagnostics panel in Settings → Notifications.
+#[cfg(target_os = "macos")]
+pub fn diagnostics() -> Diagnostics {
+    // macOS keeps permission state in System Settings and exposes it only
+    // through an async completion handler; there is nothing honest to report
+    // here beyond "the backend exists", so we don't invent a field.
+    Diagnostics {
+        platform: "macos".to_string(),
+        supported: true,
+        ..Default::default()
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn diagnostics() -> Diagnostics {
+    linux::diagnostics()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn diagnostics() -> Diagnostics {
+    Diagnostics {
+        platform: "other".to_string(),
+        supported: false,
+        ..Default::default()
+    }
+}
+
+/// Install the callback invoked when the user clicks one of our notifications,
+/// with the channel id it was posted for. Call once at startup.
+///
+/// Linux only, and cfg-gated rather than stubbed so the compiler keeps saying
+/// so: routing a click needs the daemon's `actions` capability and a thread
+/// waiting on the D-Bus signal. The macOS equivalent is a
+/// `UNUserNotificationCenterDelegate` and is not wired up — clicking there
+/// still activates the app, it just doesn't land on the channel.
+#[cfg(target_os = "linux")]
+pub fn set_activation_handler<F>(handler: F)
+where
+    F: Fn(&str) + Send + Sync + 'static,
+{
+    linux::set_activation_handler(Box::new(handler));
 }
 
 /// Production-only: ask the user once for permission to post
@@ -306,38 +405,180 @@ mod macos_modern {
 
 #[cfg(target_os = "linux")]
 mod linux {
+    use std::collections::HashMap;
     use std::path::{Path, PathBuf};
-    use std::sync::Once;
+    use std::sync::mpsc::{channel, Sender};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Duration;
 
-    use super::{desktop_entry_name, icon_name, ChannelMessage};
+    use super::{desktop_entry_name, icon_name, ChannelMessage, Diagnostics};
 
     /// Hint values are kept as module constants so the boot-time
     /// environment dump and the per-delivery log line both report the
     /// exact same strings the daemon actually sees.
+    /// freedesktop reserves the action key `default` for "the user clicked the
+    /// notification body". Daemons render no button for it, which is exactly
+    /// what we want — a chat banner should open on click, not grow an Open
+    /// button.
+    const DEFAULT_ACTION: &str = "default";
     const URGENCY_LABEL: &str = "Normal";
     const CATEGORY: &str = "im.received";
     const SOUND_NAME: &str = "message-new-instant";
     const TIMEOUT_MS: u32 = 5_000;
 
-    /// Probe the notification server once and dump its identity + capability
-    /// list to the log. GNOME Shell, KDE Plasma, dunst, mako, xfce4-notifyd
-    /// all report different combinations — this is the first place to look
-    /// when "the dock counter flashes but nothing lands in the tray".
-    static PROBE: Once = Once::new();
-    fn log_server_probe_once() {
-        PROBE.call_once(|| {
+    /// Cached identity + capability list of the notification daemon. GNOME
+    /// Shell, KDE Plasma, dunst, mako and xfce4-notifyd all report different
+    /// combinations — this is the first place to look when "the dock counter
+    /// flashes but nothing lands in the tray".
+    ///
+    /// Both probes are blocking D-Bus round trips, so this is initialised
+    /// **only from the notifier thread**. Every caller below is already on it.
+    #[derive(Default)]
+    struct Probe {
+        server: Option<ServerInfo>,
+        caps: Vec<String>,
+        error: Option<String>,
+    }
+
+    struct ServerInfo {
+        name: String,
+        vendor: String,
+    }
+
+    static PROBE: OnceLock<Probe> = OnceLock::new();
+
+    fn probe() -> &'static Probe {
+        PROBE.get_or_init(|| {
+            let mut out = Probe::default();
             match notify_rust::get_server_information() {
-                Ok(info) => log::info!(
-                    "notify server: name={} vendor={} version={} spec={}",
-                    info.name, info.vendor, info.version, info.spec_version,
-                ),
-                Err(err) => log::warn!("notify server: get_server_information failed: {err}"),
+                Ok(info) => {
+                    log::info!(
+                        "notify server: name={} vendor={} version={} spec={}",
+                        info.name,
+                        info.vendor,
+                        info.version,
+                        info.spec_version,
+                    );
+                    out.server = Some(ServerInfo {
+                        name: info.name,
+                        vendor: info.vendor,
+                    });
+                }
+                Err(err) => {
+                    log::warn!("notify server: get_server_information failed: {err}");
+                    out.error = Some(err.to_string());
+                }
             }
             match notify_rust::get_capabilities() {
-                Ok(caps) => log::info!("notify caps: {:?}", caps),
-                Err(err) => log::warn!("notify caps: get_capabilities failed: {err}"),
+                Ok(caps) => {
+                    log::info!("notify caps: {:?}", caps);
+                    out.caps = caps;
+                }
+                Err(err) => {
+                    log::warn!("notify caps: get_capabilities failed: {err}");
+                    out.error.get_or_insert_with(|| err.to_string());
+                }
             }
-        });
+            out
+        })
+    }
+
+    // ---------------------------------------------------------------------
+    // The notifier thread
+    // ---------------------------------------------------------------------
+    //
+    // One long-lived thread owns every D-Bus call this module makes. Two
+    // reasons it is a thread and not just an async command:
+    //
+    //   1. Nothing here may touch the UI thread. `Notification::show()` blocks
+    //      until the daemon answers, and when no daemon is running D-Bus tries
+    //      to service-activate one — a wait bounded only by the 25s activation
+    //      timeout. Tauri runs non-async commands on the main thread, so that
+    //      wait used to freeze the whole window.
+    //
+    //   2. Deliveries must serialise. A burst of messages arriving while the
+    //      daemon is slow would otherwise pile up concurrent blocking calls,
+    //      and the `replaces_id` bookkeeping below assumes a single writer.
+    //
+    // FIFO ordering is load-bearing: the AppImage `.desktop` integration is
+    // queued from `setup()` and has to land before the first message, or GNOME
+    // has nothing to attribute that message to.
+
+    pub enum Job {
+        Message(ChannelMessage),
+        Ping,
+        LogEnvironment {
+            binary: String,
+            product_name: String,
+            identifier: String,
+        },
+        AppImageIntegration,
+        /// Reply channel for the Settings diagnostics panel. Answered on this
+        /// thread so it observes the same probe cache the real sends use.
+        Diagnostics(Sender<Diagnostics>),
+    }
+
+    static QUEUE: OnceLock<Sender<Job>> = OnceLock::new();
+
+    fn queue() -> &'static Sender<Job> {
+        QUEUE.get_or_init(|| {
+            let (tx, rx) = channel::<Job>();
+            let spawned = std::thread::Builder::new()
+                .name("clawbits-notify".to_string())
+                .spawn(move || {
+                    // Ends when the sender is dropped, which only happens at
+                    // process exit — the sender lives in a static.
+                    for job in rx {
+                        match job {
+                            Job::Message(message) => deliver_now(&message),
+                            Job::Ping => ping_now(),
+                            Job::LogEnvironment {
+                                binary,
+                                product_name,
+                                identifier,
+                            } => log_environment_now(&binary, &product_name, &identifier),
+                            Job::AppImageIntegration => ensure_appimage_desktop_file(),
+                            Job::Diagnostics(reply) => {
+                                let _ = reply.send(collect_diagnostics());
+                            }
+                        }
+                    }
+                });
+            if let Err(err) = &spawned {
+                log::error!("notify: could not spawn notifier thread: {err}");
+            }
+            tx
+        })
+    }
+
+    pub fn enqueue(job: Job) {
+        if queue().send(job).is_err() {
+            log::error!("notify: notifier thread is gone — dropping job");
+        }
+    }
+
+    /// Ask the notifier thread for a diagnostics snapshot.
+    ///
+    /// Blocks the caller, so the command wrapping this must be off the UI
+    /// thread. The timeout is generous on purpose: the answer is worth waiting
+    /// for precisely when the daemon is being slow, which is the case a user
+    /// opens this panel to investigate.
+    pub fn diagnostics() -> Diagnostics {
+        let (tx, rx) = channel::<Diagnostics>();
+        enqueue(Job::Diagnostics(tx));
+        rx.recv_timeout(Duration::from_secs(30)).unwrap_or_else(|_| {
+            log::warn!("notify diagnostics: notifier thread did not answer in time");
+            Diagnostics {
+                platform: "linux".to_string(),
+                supported: true,
+                desktop_entry: Some(desktop_entry_name().to_string()),
+                error: Some(
+                    "The notification daemon did not respond. It may not be running."
+                        .to_string(),
+                ),
+                ..Default::default()
+            }
+        })
     }
 
     /// Candidate paths where the freedesktop `.desktop` file for this
@@ -410,7 +651,38 @@ mod linux {
         None
     }
 
-    pub fn log_environment(binary: &str, product_name: &str, identifier: &str) {
+    /// The installed `.desktop` file whose basename equals the `DesktopEntry`
+    /// hint we send — the one GNOME Shell actually matches on. `None` means
+    /// the Shell has nothing to attribute us to and will drop our
+    /// notifications, which is the single highest-signal failure on Linux.
+    fn matching_desktop_file() -> Option<PathBuf> {
+        let basenames = candidate_basenames(icon_name(), desktop_entry_name());
+        desktop_file_candidates(&basenames)
+            .into_iter()
+            .find(|path| {
+                path.exists()
+                    && path.file_stem().and_then(|s| s.to_str()) == Some(desktop_entry_name())
+            })
+    }
+
+    /// Snapshot for the Settings diagnostics panel. Runs on the notifier
+    /// thread; `probe()` may block here, which is exactly why it does.
+    pub fn collect_diagnostics() -> Diagnostics {
+        let probed = probe();
+        Diagnostics {
+            platform: "linux".to_string(),
+            supported: true,
+            server_name: probed.server.as_ref().map(|s| s.name.clone()),
+            server_vendor: probed.server.as_ref().map(|s| s.vendor.clone()),
+            capabilities: probed.caps.clone(),
+            desktop_entry: Some(desktop_entry_name().to_string()),
+            desktop_file: matching_desktop_file().map(|p| p.display().to_string()),
+            notify_send: which("notify-send"),
+            error: probed.error.clone(),
+        }
+    }
+
+    pub fn log_environment_now(binary: &str, product_name: &str, identifier: &str) {
         log::info!("--- notification environment ---");
         log::info!(
             "binary={binary} product_name={product_name:?} identifier={identifier}"
@@ -505,8 +777,8 @@ mod linux {
         // Reach out to the daemon now rather than waiting for the first
         // message — failures here mean D-Bus itself can't talk to the
         // notification server (no daemon running, sandbox blocks the
-        // bus, etc.).
-        log_server_probe_once();
+        // bus, etc.). Blocking is fine: we are on the notifier thread.
+        probe();
 
         log::info!("--- end notification environment ---");
     }
@@ -558,7 +830,7 @@ mod linux {
         //   defensive.
         let mut n = notify_rust::Notification::new();
         n.summary(summary)
-            .body(body)
+            .body(&escape_body(body))
             .icon(icon_name())
             .hint(notify_rust::Hint::DesktopEntry(desktop_entry_name().into()))
             .hint(notify_rust::Hint::Category(CATEGORY.into()))
@@ -566,6 +838,27 @@ mod linux {
             .hint(notify_rust::Hint::SoundName(SOUND_NAME.into()))
             .timeout(notify_rust::Timeout::Milliseconds(TIMEOUT_MS));
         n
+    }
+
+    /// Escape the body when the daemon parses it as markup.
+    ///
+    /// Daemons advertising `body-markup` run the body through a limited
+    /// HTML/Pango parser. Chat messages here routinely carry `<`, `&` and code
+    /// fences, and an unescaped body either renders mangled or — when the parse
+    /// fails outright — is dropped by the daemon. That reads as "notifications
+    /// are broken", intermittently, for exactly the messages that happen to
+    /// contain a bracket.
+    ///
+    /// Body only: per the freedesktop spec the summary is never markup, so
+    /// escaping it would show users literal `&amp;` in a channel name.
+    fn escape_body(body: &str) -> String {
+        if !supports("body-markup") {
+            return body.to_string();
+        }
+        // Ampersand first, or the entities introduced below get double-escaped.
+        body.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
     }
 
     /// Log the exact payload we're about to hand to `org.freedesktop.
@@ -586,8 +879,130 @@ mod linux {
         );
     }
 
-    pub fn deliver(message: &ChannelMessage) {
-        log_server_probe_once();
+    /// The banner currently on screen for a channel.
+    ///
+    /// `id` is the `replaces_id` the crate was picked for (see Cargo.toml) and
+    /// the direct counterpart of the web push payload's `tag: channel:<id>`:
+    /// the next message in a channel supersedes that channel's banner instead
+    /// of stacking a new one. Without it a chatty channel buried the tray under
+    /// one banner per message, which reads as broken every bit as much as
+    /// silence does.
+    ///
+    /// `watched` prevents a thread pile-up. Every delivery could spawn its own
+    /// `wait_for_action` thread, and because replacement reuses the same id
+    /// they would *all* still be listening to it — so one click would fire N
+    /// navigations and N zbus connections would sit open until the user finally
+    /// dismissed the banner. One watcher per live id is enough.
+    ///
+    /// Entries are dropped when the notification ends, so a message arriving
+    /// after the user dismissed a banner opens a fresh one (and re-alerts)
+    /// rather than quietly replacing something no longer on screen.
+    struct Banner {
+        id: u32,
+        watched: bool,
+    }
+
+    static BANNERS: Mutex<Option<HashMap<String, Banner>>> = Mutex::new(None);
+
+    fn previous_id(channel_id: &str) -> Option<u32> {
+        let guard = BANNERS.lock().ok()?;
+        Some(guard.as_ref()?.get(channel_id)?.id)
+    }
+
+    /// Is this id going unwatched? False when a live thread already has it.
+    fn needs_watcher(channel_id: &str, id: u32) -> bool {
+        let Ok(guard) = BANNERS.lock() else {
+            return false;
+        };
+        !guard
+            .as_ref()
+            .and_then(|map| map.get(channel_id))
+            .is_some_and(|banner| banner.watched && banner.id == id)
+    }
+
+    /// Store the banner now on screen for a channel. `watched` must say
+    /// whether a thread is *actually* listening to this id, not whether we
+    /// wanted one — see the call site.
+    fn record(channel_id: &str, id: u32, watched: bool) {
+        if let Ok(mut guard) = BANNERS.lock() {
+            guard
+                .get_or_insert_with(HashMap::new)
+                .insert(channel_id.to_string(), Banner { id, watched });
+        }
+    }
+
+    /// Forget a banner once it is off screen — but only if it is still the one
+    /// we know about. A newer delivery may already have taken this channel's
+    /// slot, and dropping that would lose a live `replaces_id`.
+    fn forget(channel_id: &str, id: u32) {
+        if let Ok(mut guard) = BANNERS.lock() {
+            if let Some(map) = guard.as_mut() {
+                if map.get(channel_id).is_some_and(|banner| banner.id == id) {
+                    map.remove(channel_id);
+                }
+            }
+        }
+    }
+
+    /// Does the daemon advertise a capability? GNOME Shell, Plasma, dunst and
+    /// mako all differ; `probe()` cached the list on first use.
+    fn supports(capability: &str) -> bool {
+        probe().caps.iter().any(|c| c == capability)
+    }
+
+    /// Called when the user clicks one of our notifications, with the channel
+    /// id it carried. Installed by `lib.rs` so this module needs no dependency
+    /// on Tauri — it is spawned from a plain worker thread, and keeping the
+    /// boundary a callback is what lets the whole module be type-checked for
+    /// Linux from a host that isn't Linux.
+    type ActivationHandler = Box<dyn Fn(&str) + Send + Sync + 'static>;
+    static ON_ACTIVATE: OnceLock<ActivationHandler> = OnceLock::new();
+
+    pub fn set_activation_handler(handler: ActivationHandler) {
+        if ON_ACTIVATE.set(handler).is_err() {
+            log::warn!("notify: activation handler was already installed");
+        }
+    }
+
+    /// Wait for the user to act on one notification, on a thread of its own.
+    ///
+    /// `wait_for_action` consumes the handle and blocks until the daemon
+    /// reports either an invoked action or a close, so it cannot run on the
+    /// notifier thread — that thread has to stay free to deliver the next
+    /// message. Either outcome ends the thread.
+    ///
+    /// Returns whether the thread actually started, so the caller can leave
+    /// `watched` false and try again on the next message if it did not.
+    fn watch_for_activation(handle: notify_rust::NotificationHandle, channel_id: String) -> bool {
+        let id = handle.id();
+        let spawned = std::thread::Builder::new()
+            .name("clawbits-notify-action".to_string())
+            .spawn(move || {
+                handle.wait_for_action(|action| {
+                    // notify-rust reports a dismissal as the pseudo-action
+                    // "__closed"; anything that isn't our own key is a close.
+                    if action == DEFAULT_ACTION {
+                        log::info!("notify activated: channel_id={channel_id:?} id={id}");
+                        if let Some(handler) = ON_ACTIVATE.get() {
+                            handler(&channel_id);
+                        } else {
+                            log::warn!("notify activated but no handler is installed");
+                        }
+                    }
+                    forget(&channel_id, id);
+                });
+            });
+        match spawned {
+            Ok(_) => true,
+            Err(err) => {
+                log::warn!("notify: could not spawn action watcher: {err}");
+                false
+            }
+        }
+    }
+
+    fn deliver_now(message: &ChannelMessage) {
+        probe();
         // Body folds the author in since Linux notifications have no
         // subtitle slot. For DMs (where the channel name IS the author)
         // we'd otherwise read "Dmytro Tkachuk: msg" with "Dmytro Tkachuk"
@@ -597,17 +1012,42 @@ mod linux {
         } else {
             format!("{}: {}", message.author_name, message.body)
         };
+        let replaces = previous_id(&message.channel_id);
         let extra = format!(
-            "channel_id={:?} channel_name={:?} author={:?} ",
-            message.channel_id, message.channel_name, message.author_name,
+            "channel_id={:?} channel_name={:?} author={:?} replaces_id={:?} ",
+            message.channel_id, message.channel_name, message.author_name, replaces,
         );
         log_payload(&message.channel_name, &body, "message", &extra);
-        match base_notification(&message.channel_name, &body).show() {
-            Ok(handle) => log::info!(
-                "notify result (message): OK id={} channel_id={:?}",
-                handle.id(),
-                message.channel_id,
-            ),
+
+        let mut notification = base_notification(&message.channel_name, &body);
+        if let Some(id) = replaces {
+            notification.id(id);
+        }
+        // Only offered when the daemon says it handles actions at all. Per
+        // spec an unsupported action is ignored, but a couple of daemons
+        // render a stray button for it instead.
+        let actionable = supports("actions");
+        if actionable {
+            notification.action(DEFAULT_ACTION, "Open");
+        }
+
+        match notification.show() {
+            Ok(handle) => {
+                let id = handle.id();
+                log::info!(
+                    "notify result (message): OK id={} channel_id={:?}",
+                    id,
+                    message.channel_id,
+                );
+                // At most one watcher per live id. A replacement reuses the
+                // id, so a thread already waiting on it is still the right
+                // one; `||` short-circuits before the handle is moved.
+                // Recording last, with whether anything is *actually*
+                // listening, keeps a failed spawn from marking it watched.
+                let watched = !needs_watcher(&message.channel_id, id)
+                    || (actionable && watch_for_activation(handle, message.channel_id.clone()));
+                record(&message.channel_id, id, watched);
+            }
             Err(err) => log::error!(
                 "notify result (message): ERR channel_id={:?} err={err:#}",
                 message.channel_id,
@@ -615,14 +1055,17 @@ mod linux {
         }
     }
 
-    /// One-shot debug ping. Lets the user trigger a hand-crafted test
-    /// notification from DevTools (`invoke('notify_debug_ping')`) without
-    /// needing a real incoming chat message. The payload is intentionally
-    /// minimal and all-ASCII so we can rule out malformed body content.
-    pub fn debug_ping() {
-        log_server_probe_once();
-        let summary = "Clawbits debug ping";
-        let body = "If you see this, the daemon is wired up.";
+    /// One-shot test notification, triggered from Settings → Notifications.
+    /// Lets a user prove out the path without needing a second account to post
+    /// a real message. The payload is intentionally minimal and all-ASCII so a
+    /// failure can't be blamed on malformed body content.
+    ///
+    /// Deliberately carries no `replaces_id`: the test must produce a visible
+    /// banner every time it is pressed, not silently overwrite the last one.
+    fn ping_now() {
+        probe();
+        let summary = "Clawbits";
+        let body = "Test notification - delivery is working.";
         log_payload(summary, body, "debug-ping", "");
         match base_notification(summary, body).show() {
             Ok(handle) => log::info!("notify result (debug-ping): OK id={}", handle.id()),
@@ -641,7 +1084,7 @@ mod linux {
     /// Idempotent: rewrites only when the file is missing or its `Exec`
     /// no longer points at the current AppImage (it moved or
     /// auto-updated). No-op when `APPIMAGE` is unset (`.deb` / dev run).
-    pub fn ensure_appimage_desktop_file() {
+    fn ensure_appimage_desktop_file() {
         // The AppImage runtime exports APPIMAGE (absolute path to the
         // .AppImage) and APPDIR (mounted squashfs root). Both are absent
         // on .deb installs and `cargo tauri dev`, so this whole routine
@@ -763,12 +1206,31 @@ mod linux {
     }
 }
 
-/// Trigger a hand-crafted debug notification. Linux-only path is wired
-/// up; on macOS and Windows it logs and returns so the JS caller doesn't
-/// crash if a developer invokes it on the wrong platform.
+/// Trigger a hand-crafted test notification through the same delivery path as
+/// a real message.
+///
+/// Reachable from Settings → Notifications on every desktop platform. It used
+/// to be Linux-only and DevTools-only, which meant the one platform where
+/// delivery is fragile had no way for a user to tell "the daemon dropped it"
+/// apart from "the app never sent it" — the log line this produces is exactly
+/// that distinction.
 pub fn debug_ping() {
     #[cfg(target_os = "linux")]
-    linux::debug_ping();
-    #[cfg(not(target_os = "linux"))]
-    log::info!("notify debug_ping called on non-Linux platform — no-op");
+    linux::enqueue(linux::Job::Ping);
+
+    #[cfg(target_os = "macos")]
+    {
+        // Routed through the real delivery path rather than a bespoke one, so
+        // a passing test genuinely exercises what messages use.
+        let message = ChannelMessage {
+            channel_id: "clawbits-test".to_string(),
+            channel_name: "Clawbits".to_string(),
+            author_name: "Clawbits".to_string(),
+            body: "Test notification — delivery is working.".to_string(),
+        };
+        deliver(&message);
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    log::info!("notify debug_ping: no native backend on this platform — no-op");
 }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -79,17 +79,33 @@ self.addEventListener("notificationclick", (event) => {
   const data = event.notification.data || {};
   const url = data.url || "/";
 
+  // The server sends an absolute URL on the app origin. Only a client on THAT
+  // origin runs the app and can act on `push-navigate`; a same-origin tab of
+  // some other site (which is what `matchAll` would hand back to a registration
+  // left over on the old apex) would swallow the message and leave the user
+  // staring at the page they were already on. When the target is elsewhere,
+  // skip the focus path and open a window at it.
+  let sameOrigin = true;
+  try {
+    const target = new URL(url, self.location.origin);
+    sameOrigin = target.origin === self.location.origin;
+  } catch {
+    /* malformed — treat as a path on this origin */
+  }
+
   event.waitUntil(
     (async () => {
-      const windows = await self.clients.matchAll({
-        type: "window",
-        includeUncontrolled: true,
-      });
-      for (const client of windows) {
-        if ("focus" in client) {
-          await client.focus();
-          client.postMessage({ type: "push-navigate", url });
-          return;
+      if (sameOrigin) {
+        const windows = await self.clients.matchAll({
+          type: "window",
+          includeUncontrolled: true,
+        });
+        for (const client of windows) {
+          if ("focus" in client) {
+            await client.focus();
+            client.postMessage({ type: "push-navigate", url });
+            return;
+          }
         }
       }
       if (self.clients.openWindow) {

--- a/frontend/src/hooks/useDesktopNav.ts
+++ b/frontend/src/hooks/useDesktopNav.ts
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { isDesktop, listenForOpenChannel } from "@/lib/desktop";
+import {
+  isDesktop,
+  listenForNotificationActivation,
+  listenForOpenChannel,
+} from "@/lib/desktop";
 
 /**
  * Wires the native View menu (Back / Forward / Reload) and Cmd+[/]
@@ -9,7 +13,9 @@ import { isDesktop, listenForOpenChannel } from "@/lib/desktop";
  *
  * Also subscribes to `desktop://open-channel` so Window → Recent menu
  * clicks navigate to the right route via react-router (rather than a
- * full window.location swap that would drop component state).
+ * full window.location swap that would drop component state), and to
+ * `clawbits://notification-activated` so clicking a native notification lands
+ * on the channel it came from.
  */
 export function useDesktopNav() {
   const navigate = useNavigate();
@@ -34,6 +40,17 @@ export function useDesktopNav() {
     let dispose: (() => void) | undefined;
     void (async () => {
       dispose = await listenForOpenChannel((path) => navigate(path));
+    })();
+    return () => { dispose?.(); };
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!isDesktop) return;
+    let dispose: (() => void) | undefined;
+    void (async () => {
+      dispose = await listenForNotificationActivation((path) => {
+        void navigate(path);
+      });
     })();
     return () => { dispose?.(); };
   }, [navigate]);

--- a/frontend/src/hooks/useGlobalEvents.ts
+++ b/frontend/src/hooks/useGlobalEvents.ts
@@ -12,6 +12,26 @@ import { toast } from "@/lib/toast";
 
 const EMPTY_TOKENS: ReadonlySet<string> = new Set<string>();
 
+/**
+ * What a desktop notification should actually say for a post.
+ *
+ * The sidebar snippet can be empty for a file-only post because the row shows
+ * a paperclip next to it; a notification has no such affordance, so an empty
+ * body left the banner reading "Author:" and nothing else. Mirrors the
+ * server-side `_preview` that builds the web push payload
+ * (clawbits/realtime/web_push.py) so both surfaces say the same thing.
+ *
+ * Whitespace is collapsed for the same reason: a pasted multi-line message
+ * became a multi-line banner.
+ */
+function notificationBody(preview: string, attachmentCount: number): string {
+  const text = preview.replace(/\s+/g, " ").trim();
+  if (text) return text;
+  if (attachmentCount === 1) return "Sent an attachment";
+  if (attachmentCount > 1) return `Sent ${String(attachmentCount)} attachments`;
+  return "New message";
+}
+
 type ChannelsCache = { channels: MmChannel[]; total: number };
 type OrgsCache = { organizations: Org[]; total: number };
 
@@ -245,7 +265,7 @@ export function useGlobalEvents({
               channelId: evt.channel_id,
               channelName: isDirect ? titleName : `#${titleName}`,
               authorName: post.poster_display_name ?? "Someone",
-              body: preview,
+              body: notificationBody(preview, attachmentCount),
             });
           }
         }

--- a/frontend/src/lib/desktop.ts
+++ b/frontend/src/lib/desktop.ts
@@ -322,14 +322,42 @@ export async function setDockBadge(count: number): Promise<void> {
 }
 
 /**
+ * Is the user actually looking at the app right now?
+ *
+ * `document.hasFocus()` is not trustworthy in the desktop shell. Closing the
+ * window hides it rather than destroying it (see the CloseRequested handler in
+ * src-tauri/src/lib.rs), and WebKitGTK does not reliably clear the document's
+ * focus flag when the GTK window is hidden — so on Linux `hasFocus()` could
+ * keep reporting `true` for a window the user cannot see, suppressing every
+ * notification for the entire session.
+ *
+ * The window manager is the authority, so ask Tauri. Both conditions are
+ * required: a minimised or fully-hidden window still reports visible on some
+ * platforms, and a window on another workspace is visible but not focused.
+ * Falls back to the DOM only if the Tauri call fails outright.
+ */
+export async function isAppInForeground(): Promise<boolean> {
+  const domFocus = typeof document !== "undefined" && document.hasFocus();
+  if (!isDesktop) return domFocus;
+  try {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    const win = getCurrentWindow();
+    const [visible, focused] = await Promise.all([win.isVisible(), win.isFocused()]);
+    return visible && focused;
+  } catch {
+    return domFocus;
+  }
+}
+
+/**
  * Fire a native desktop notification for an incoming chat message.
  *
- * Routes through the `notify_channel_message` Rust command instead of
- * the Tauri notification plugin so we can pass `channelId` — the
- * Rust side keeps a per-channel running counter and re-uses the same
- * native identifier across deliveries, which makes the notification
- * update in place rather than stack. The Tauri plugin discards
- * identifier/group fields on desktop, hence the bypass.
+ * Routes through the `notify_channel_message` Rust command instead of the
+ * Tauri notification plugin so we can pass `channelId`: the Rust side keeps
+ * the last notification id per channel and replaces that banner in place
+ * (`replaces_id` on Linux, `threadIdentifier` grouping on macOS) rather than
+ * stacking one banner per message. The Tauri plugin discards identifier/group
+ * fields on desktop, hence the bypass.
  */
 export async function notifyForPost(opts: {
   channelId: string;
@@ -340,7 +368,7 @@ export async function notifyForPost(opts: {
   if (!isDesktop) return;
   // Skip when the user is already looking at the app — the unread badge
   // is feedback enough; a notification would be redundant noise.
-  if (typeof document !== "undefined" && document.hasFocus()) return;
+  if (await isAppInForeground()) return;
 
   try {
     const { invoke } = await import("@tauri-apps/api/core");
@@ -354,6 +382,44 @@ export async function notifyForPost(opts: {
     });
   } catch {
     /* Notification daemon unavailable or user denied — silent failure. */
+  }
+}
+
+/** What the shell can tell us about native notification delivery. Mirrors the
+ *  `Diagnostics` struct in src-tauri/src/notifications.rs. */
+export interface NotificationDiagnostics {
+  /** "linux" | "macos" | "other" */
+  platform: string;
+  supported: boolean;
+  serverName: string | null;
+  serverVendor: string | null;
+  capabilities: string[];
+  /** The `DesktopEntry` hint we send, and the installed .desktop file matching
+   *  it. A hint with no matching file is why GNOME drops notifications. */
+  desktopEntry: string | null;
+  desktopFile: string | null;
+  notifySend: string | null;
+  error: string | null;
+}
+
+/** Fire a test notification through the real delivery path. Throws when the
+ *  command itself fails, which is distinct from the daemon dropping it — the
+ *  caller should say so rather than claiming success. */
+export async function sendTestNotification(): Promise<void> {
+  if (!isDesktop) throw new Error("not running in the desktop app");
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("notify_debug_ping");
+}
+
+/** Read notification diagnostics from the shell. Returns null off-desktop or
+ *  when the shell is too old to know the command. */
+export async function getNotificationDiagnostics(): Promise<NotificationDiagnostics | null> {
+  if (!isDesktop) return null;
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<NotificationDiagnostics>("notify_diagnostics");
+  } catch {
+    return null;
   }
 }
 
@@ -593,4 +659,34 @@ export async function listenForOpenChannel(
     }
   });
   return unlisten;
+}
+
+// =========================================================================
+// Notification click
+// =========================================================================
+// Rust emits `clawbits://notification-activated` with the channel id when the
+// user clicks one of our native notifications. The shell has already raised
+// the window by the time this arrives; all that is left is to land on the
+// right channel — the desktop counterpart of the service worker's
+// `push-navigate` message on the web (see lib/push.ts).
+//
+// Linux only today: routing a click needs the notification daemon's `actions`
+// capability. On macOS a click still activates the app but stays wherever the
+// user was, until a UNUserNotificationCenterDelegate is wired up.
+
+export async function listenForNotificationActivation(
+  navigate: (path: string) => void,
+): Promise<() => void> {
+  const noop = (): void => {
+    /* no listener to detach on web */
+  };
+  if (!isDesktop) return noop;
+  const { listen } = await import("@tauri-apps/api/event");
+  return await listen<string>("clawbits://notification-activated", (event) => {
+    const channelId = event.payload;
+    // The payload is an opaque channel id from our own shell, but it lands in
+    // a router path, so keep it to characters an id can actually contain.
+    if (typeof channelId !== "string" || !/^[A-Za-z0-9_-]+$/.test(channelId)) return;
+    navigate(`/channels/${channelId}`);
+  });
 }

--- a/frontend/src/lib/push.test.ts
+++ b/frontend/src/lib/push.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { pushTargetToPath } from "./push";
+
+// The function reads window.location.origin; jsdom's own origin stands in for
+// the app host, so the cases below are about origin *identity*, not the literal
+// hostname. APP is the real one, used only where a mismatch is the point.
+const APP = "https://app.clawbits.ai";
+const HERE = window.location.origin;
+
+describe("pushTargetToPath", () => {
+  // The bug this exists for: the payload carries an absolute URL so a service
+  // worker left over on the old apex opens the right host, but react-router
+  // must still be handed a path.
+  it("folds an absolute app URL down to a path", () => {
+    expect(pushTargetToPath(`${HERE}/channels/abc`)).toBe("/channels/abc");
+    expect(pushTargetToPath(`${HERE}/`)).toBe("/");
+  });
+
+  it("keeps the query and hash", () => {
+    expect(pushTargetToPath(`${HERE}/channels/abc?post=1#p2`)).toBe(
+      "/channels/abc?post=1#p2",
+    );
+  });
+
+  it("passes a bare path through", () => {
+    expect(pushTargetToPath("/channels/abc")).toBe("/channels/abc");
+  });
+
+  // Cross-origin -> null, so the caller hard-navigates instead of soft-routing
+  // to a path on the wrong host. This is what a pre-cutover apex registration
+  // looks like from inside the app.
+  it("refuses a cross-origin target", () => {
+    expect(pushTargetToPath(`${APP}/channels/abc`)).toBeNull();
+    expect(pushTargetToPath("https://clawbits.ai/channels/abc")).toBeNull();
+    expect(pushTargetToPath("https://evil.example/steal")).toBeNull();
+  });
+
+  // Anything that is not an absolute URL is a relative reference and resolves
+  // against the app origin - which is the right answer for it, not an error.
+  it("resolves a relative target against the app origin", () => {
+    expect(pushTargetToPath("channels/abc")).toBe("/channels/abc");
+  });
+});

--- a/frontend/src/lib/push.ts
+++ b/frontend/src/lib/push.ts
@@ -150,6 +150,26 @@ export async function refreshPushOnLoad(): Promise<void> {
   }
 }
 
+/** Fold a push payload's target into something react-router can navigate to.
+ *
+ *  The server sends an ABSOLUTE URL on the app origin (so a service worker
+ *  registered on the old apex still opens the right host — see the backend's
+ *  ``_build_payload``). react-router treats its argument as a path, so
+ *  ``navigate("https://app.clawbits.ai/channels/x")`` would route to a garbage
+ *  path. Strip the origin when it is ours; return null for a genuinely
+ *  cross-origin URL so the caller can hard-navigate instead of soft-routing
+ *  somewhere it doesn't belong. Bare paths pass through unchanged. */
+export function pushTargetToPath(raw: string): string | null {
+  if (raw.startsWith("/")) return raw;
+  try {
+    const url = new URL(raw, window.location.origin);
+    if (url.origin !== window.location.origin) return null;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
 /** Soft-navigate when the service worker reports a notification click. The SW
  *  posts ``{type:"push-navigate", url}`` to the focused client. Returns a
  *  cleanup fn. No-op on desktop / unsupported. */
@@ -160,7 +180,9 @@ export function setupPushClickNavigation(navigate: (url: string) => void): () =>
   const handler = (event: MessageEvent) => {
     const data = event.data as { type?: string; url?: string } | null;
     if (data?.type === "push-navigate" && typeof data.url === "string") {
-      navigate(data.url);
+      const path = pushTargetToPath(data.url);
+      if (path) navigate(path);
+      else window.location.assign(data.url);
     }
   };
   navigator.serviceWorker.addEventListener("message", handler);

--- a/frontend/src/pages/SettingsNotificationsPage.tsx
+++ b/frontend/src/pages/SettingsNotificationsPage.tsx
@@ -1,13 +1,20 @@
+import { useEffect, useState } from "react";
 import {
     Notification03Icon as Bell,
     SquareArrowUp01Icon as ShareUp,
 } from "@hugeicons/core-free-icons";
 
+import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Icon } from "@/components/Icon";
 import { PageHeader } from "@/components/PageHeader";
 import { usePushSubscription } from "@/lib/push";
-import { isDesktop } from "@/lib/desktop";
+import {
+    getNotificationDiagnostics,
+    isDesktop,
+    sendTestNotification,
+    type NotificationDiagnostics,
+} from "@/lib/desktop";
 import { toast } from "@/lib/toast";
 
 /**
@@ -22,6 +29,23 @@ import { toast } from "@/lib/toast";
  */
 export default function SettingsNotificationsPage() {
     const push = usePushSubscription();
+    const diagnostics = useNotificationDiagnostics();
+    const [testing, setTesting] = useState(false);
+
+    const handleTest = async () => {
+        setTesting(true);
+        try {
+            await sendTestNotification();
+            // Deliberately not "sent!" — the command succeeding only means the
+            // shell accepted it. On Linux the daemon can still drop it, and
+            // that gap is the whole point of the button.
+            toast.success("Test sent - you should see a banner shortly");
+        } catch {
+            toast.error("Couldn't send a test notification");
+        } finally {
+            setTesting(false);
+        }
+    };
 
     const handleToggle = async (next: boolean) => {
         if (!next) {
@@ -56,10 +80,27 @@ export default function SettingsNotificationsPage() {
 
                 {/* The control surface adapts to what this runtime can actually do. */}
                 {isDesktop ? (
-                    <p className="border-t border-border/40 pt-4 text-xs text-muted-foreground">
-                        Clawbits for desktop uses your system&apos;s native notifications -
-                        nothing to turn on here.
-                    </p>
+                    <div className="space-y-4 border-t border-border/40 pt-4">
+                        <div className="flex items-center gap-4">
+                            <div className="min-w-0 flex-1 space-y-0.5">
+                                <p className="text-sm font-medium">System notifications</p>
+                                <p className="text-xs text-muted-foreground">
+                                    Clawbits for desktop uses your system&apos;s own
+                                    notifications - nothing to turn on here. Send a test to
+                                    check they reach you.
+                                </p>
+                            </div>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={testing}
+                                onClick={() => { void handleTest(); }}
+                            >
+                                Send a test
+                            </Button>
+                        </div>
+                        <DesktopDeliveryReport diagnostics={diagnostics} />
+                    </div>
                 ) : push.status === "install-required" ? (
                     <div className="flex gap-3 rounded-lg border border-border/60 bg-muted/40 p-3.5">
                         <Icon icon={ShareUp} className="size-5 shrink-0 text-muted-foreground" />
@@ -111,4 +152,110 @@ export default function SettingsNotificationsPage() {
             </section>
         </div>
     );
+}
+
+/**
+ * Load the shell's notification diagnostics once, on desktop only.
+ *
+ * On Linux the underlying command talks to the notification daemon over D-Bus
+ * and can take a moment when that daemon is slow or absent - which is exactly
+ * when a user opens this page - so it runs off the render path and the panel
+ * simply shows nothing until it answers.
+ */
+function useNotificationDiagnostics(): NotificationDiagnostics | null {
+    const [diagnostics, setDiagnostics] = useState<NotificationDiagnostics | null>(null);
+
+    useEffect(() => {
+        if (!isDesktop) return;
+        let live = true;
+        void getNotificationDiagnostics().then((result) => {
+            if (live) setDiagnostics(result);
+        });
+        return () => {
+            live = false;
+        };
+    }, []);
+
+    return diagnostics;
+}
+
+/**
+ * What the desktop shell knows about whether notifications can actually be
+ * delivered here.
+ *
+ * All of this was already collected at every boot and written to the log file,
+ * where it only helped someone who knew the file existed. Surfacing it turns
+ * "notifications don't work" into a report that names the daemon and says
+ * whether the desktop environment has anything to attribute us to.
+ *
+ * Silent on macOS: the OS owns permission state and there is nothing here we
+ * could tell the user that System Settings doesn't say better.
+ */
+function DesktopDeliveryReport({
+    diagnostics,
+}: {
+    diagnostics: NotificationDiagnostics | null;
+}) {
+    if (diagnostics?.platform !== "linux") return null;
+
+    // Ordered by how badly each one breaks delivery.
+    if (diagnostics.error) {
+        return (
+            <Report tone="warning" title="No notification daemon is answering">
+                Your desktop isn&apos;t running a notification service, so nothing can
+                be shown. On a minimal window manager you may need to start one
+                yourself - <Term>dunst</Term> and <Term>mako</Term> are common choices.
+            </Report>
+        );
+    }
+
+    if (diagnostics.desktopEntry && !diagnostics.desktopFile) {
+        return (
+            <Report tone="warning" title="This install isn't registered with your desktop">
+                Nothing on this system matches{" "}
+                <Term>{diagnostics.desktopEntry}.desktop</Term>, and GNOME drops
+                notifications from apps it can&apos;t attribute. Installing the{" "}
+                <Term>.deb</Term> registers it; an AppImage registers itself on first
+                launch, so this usually means it was moved after being run.
+            </Report>
+        );
+    }
+
+    return (
+        <Report tone="quiet" title={`Delivered by ${diagnostics.serverName ?? "your desktop"}`}>
+            Registered as <Term>{diagnostics.desktopEntry ?? "clawbits"}</Term>. If a
+            test doesn&apos;t appear, check that Clawbits is allowed in your desktop&apos;s
+            own notification settings.
+        </Report>
+    );
+}
+
+function Report({
+    tone,
+    title,
+    children,
+}: {
+    tone: "quiet" | "warning";
+    title: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <div
+            className={
+                // --destructive, not --signal: index.css fences --signal to
+                // navigation intent and forbids it from marking status.
+                tone === "warning"
+                    ? "space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 p-3.5"
+                    : "space-y-1 rounded-lg border border-border/60 bg-muted/40 p-3.5"
+            }
+        >
+            <p className="text-xs font-medium text-foreground">{title}</p>
+            <p className="text-xs leading-relaxed text-muted-foreground">{children}</p>
+        </div>
+    );
+}
+
+/** Inline literal - a file name, a package, a command. */
+function Term({ children }: { children: React.ReactNode }) {
+    return <code className="rounded bg-muted px-1 py-0.5 text-[11px]">{children}</code>;
 }

--- a/web/worker/index.ts
+++ b/web/worker/index.ts
@@ -22,11 +22,11 @@ import { isAiCrawler } from "../src/lib/crawlers";
  *
  * WHY IT BARELY RUNS
  *
- * `assets.run_worker_first` in wrangler.jsonc lists exactly two patterns, so
- * every other request on the site - every doc page, every asset, every .md
- * endpoint - is served straight from the asset store with no Worker invocation
- * at all, exactly as before. The Worker is on the path for `/` and `/_bot/*`
- * and nothing else.
+ * `assets.run_worker_first` in wrangler.jsonc lists a short, explicit set of
+ * patterns, so every other request on the site - every doc page, every asset,
+ * every .md endpoint - is served straight from the asset store with no Worker
+ * invocation at all, exactly as before. The Worker is on the path for `/`,
+ * `/_bot/*`, and the handful of legacy app routes below, and nothing else.
  *
  * WHAT IT IS CAREFUL ABOUT
  *
@@ -51,9 +51,59 @@ interface Env {
 /** The variant's path in the asset store. Written by build-bot-page.mjs. */
 const BOT_PAGE = "/_bot/";
 
+/**
+ * Paths the app owns, which the apex used to serve and now 404s.
+ *
+ * The app moved to app.<zone> in the apex cutover (2026-08-12), but browsers
+ * that had granted web-push before that still hold a service-worker
+ * registration on the apex, and a notification click there landed on this
+ * site's 404 page. The payload now carries an absolute app-origin URL, which
+ * fixes new pushes; this catches everything that predates it - notifications
+ * already sitting in the tray, bookmarks, links pasted before the move.
+ *
+ * Deliberately narrow: only prefixes this site has no page of its own for, and
+ * matched on whole path segments so a marketing page is never shadowed by a
+ * near-miss - /agent-pit is a page here, /agents is not.
+ */
+const APP_PATH_PREFIXES = [
+  "/channels",
+  "/home",
+  "/agents",
+  "/skills",
+  "/automations",
+  "/settings",
+  "/login",
+];
+
+/** The app host for the zone this request arrived on, so the staging worker
+ *  never bounces anyone into production. Unknown hosts get null - a preview or
+ *  *.workers.dev deploy should keep 404ing rather than guess. */
+function appOriginFor(hostname: string): string | null {
+  for (const zone of ["clawbits.ai", "freeclaws.ai"]) {
+    if (hostname === zone || hostname.endsWith(`.${zone}`))
+      return `https://app.${zone}`;
+  }
+  return null;
+}
+
+function legacyAppRedirect(url: URL): Response | null {
+  const owned = APP_PATH_PREFIXES.some(
+    (p) => url.pathname === p || url.pathname.startsWith(`${p}/`),
+  );
+  if (!owned) return null;
+  const origin = appOriginFor(url.hostname);
+  if (!origin) return null;
+  return Response.redirect(`${origin}${url.pathname}${url.search}`, 302);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+
+    // App routes that outlived the apex cutover. See the note on
+    // APP_PATH_PREFIXES.
+    const moved = legacyAppRedirect(url);
+    if (moved) return moved;
 
     // Not a URL. See the note above.
     if (url.pathname.startsWith("/_bot")) {

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -20,7 +20,7 @@
     // request 500s.
     "binding": "ASSETS",
 
-    // The Worker runs ONLY on these two patterns. Everything else on the site -
+    // The Worker runs ONLY on these patterns. Everything else on the site -
     // every doc page, every /_astro/* bundle, every .md endpoint - is served
     // straight from the asset store with no Worker invocation, exactly as it
     // was before the Worker existed. Deleting this line does not break the
@@ -29,7 +29,24 @@
     //   /       - where the crawler/human branch happens.
     //   /_bot/* - where it is refused, so the trimmed variant never becomes a
     //             second crawlable copy of the homepage.
-    "run_worker_first": ["/", "/_bot/*"],
+    //
+    // The rest are app routes the apex served before the cutover and now 404s
+    // (a stale web-push service worker on this origin still opens them). The
+    // Worker 302s them to app.<zone>; see APP_PATH_PREFIXES in worker/index.ts,
+    // which is what actually decides - anything it does not own falls straight
+    // through to the asset store. These are listed wider than that check on
+    // purpose, so a near-miss costs one Worker invocation, never a 404.
+    "run_worker_first": [
+      "/",
+      "/_bot/*",
+      "/channels/*",
+      "/home*",
+      "/agents*",
+      "/skills*",
+      "/automations*",
+      "/settings*",
+      "/login*"
+    ],
 
     // Without this, `not_found_handling` defaults to "none" and every miss
     // returns a bare zero-byte 404 - dist/404.html is built and then never


### PR DESCRIPTION
This pull request implements a robust fix for issues caused by the migration of the web app from the apex domain (`clawbits.ai`/`freeclaws.ai`) to a dedicated subdomain (`app.clawbits.ai`). It ensures that web push notifications, service worker navigation, and legacy bookmarks/links all correctly route users to the app, even if their service worker registration predates the migration. The changes also update the worker and deployment config to intercept and redirect legacy app routes from the apex to the correct app host.

The most important changes are:

**Web Push Payloads and Navigation:**
- The backend now always sends an absolute URL on the app origin (`APP_URL`) in web push payloads, ensuring even clients with stale service worker registrations on the apex domain are directed to the correct host (`clawbits/domain.py`, `clawbits/realtime/web_push.py`). [[1]](diffhunk://#diff-d01604bba610dce88c0f317943f563ccb08c03841ff81a44cc94a964e8f0d8b2R10-R11) [[2]](diffhunk://#diff-d01604bba610dce88c0f317943f563ccb08c03841ff81a44cc94a964e8f0d8b2R31-R36) [[3]](diffhunk://#diff-e65e52bfcd2c7158fb6407388daba2a88a4d52d476169df8b92d76a5b9ff0d4cR32-R33) [[4]](diffhunk://#diff-e65e52bfcd2c7158fb6407388daba2a88a4d52d476169df8b92d76a5b9ff0d4cL372-R382)
- The service worker (`frontend/public/sw.js`) checks if the notification click target is same-origin; if not, it opens a new window at the absolute URL instead of trying to soft-navigate, preventing navigation to a 404 page on the marketing site. [[1]](diffhunk://#diff-c9d15d0b52a92009dfcb16c822c366c3ab1532bae3d977c3e857b183fe8ed98eR82-R98) [[2]](diffhunk://#diff-c9d15d0b52a92009dfcb16c822c366c3ab1532bae3d977c3e857b183fe8ed98eR110)

**Frontend Path Handling:**
- Introduced `pushTargetToPath` in `frontend/src/lib/push.ts` to fold absolute app URLs down to paths for React Router, and to reject cross-origin URLs, preventing incorrect navigation. The function is fully tested (`push.test.ts`). [[1]](diffhunk://#diff-3d26643985dfc62b7dc2eb5bf961b84811e769ca1824cdc0f8c7963465c64dbeR153-R172) [[2]](diffhunk://#diff-3d26643985dfc62b7dc2eb5bf961b84811e769ca1824cdc0f8c7963465c64dbeL163-R185) [[3]](diffhunk://#diff-d9a692e08b98cd4e6fb54978f93b51eeada98d5115ff83834dc79e344098a268R1-R44)

**Apex Worker Redirects:**
- The Cloudflare Worker now intercepts legacy app routes on the apex domain and 302-redirects them to the correct app subdomain, using an explicit list of path prefixes (`APP_PATH_PREFIXES`). This ensures old bookmarks and pre-migration notification clicks are handled gracefully (`web/worker/index.ts`). [[1]](diffhunk://#diff-d2485cd32bc664e8fe62f43f2558d3ac1ad3eff42000a46248bebde1c97eac8cL25-R29) [[2]](diffhunk://#diff-d2485cd32bc664e8fe62f43f2558d3ac1ad3eff42000a46248bebde1c97eac8cR54-R107)

**Deployment Configuration:**
- Updated `web/wrangler.jsonc` to expand `run_worker_first` with all legacy app routes, ensuring the Worker handles these requests and performs the necessary redirects. [[1]](diffhunk://#diff-189cd30f7e4db147718767a051d2fbdd87db84109122913509a1e7299d08835aL23-R23) [[2]](diffhunk://#diff-189cd30f7e4db147718767a051d2fbdd87db84109122913509a1e7299d08835aL32-R49)

These changes collectively ensure seamless user navigation and notification handling across the migration, preventing users from landing on broken pages due to stale service worker registrations or outdated links.