### PR TITLE
Split openclaw into channel and tool plugin

### DIFF
--- a/.github/workflows/publish-clawhub-plugin.yaml
+++ b/.github/workflows/publish-clawhub-plugin.yaml
@@ -1,8 +1,8 @@
 name: Publish ClawBits Plugin to ClawHub
 
-# Plugin releases are automatic and message-agnostic, the same way the IronClaw
-# channel works (see publish-ironclaw-channel.yaml). On a push to main that
-# touches plugin/**, this workflow:
+# Ordered second half of the coordinated Clawbits release. The companion
+# workflow builds, validates, and publishes first. Only its successful
+# completion starts this channel release for the exact same commit.
 #
 #   1. tests + typechecks plugin/.
 #   2. stamps a version: major.minor is hand-controlled in plugin/package.json,
@@ -18,33 +18,33 @@ name: Publish ClawBits Plugin to ClawHub
 # Bump major/minor by hand in plugin/package.json + plugin/openclaw.plugin.json
 # only for a deliberate semantic jump; the patch takes care of itself.
 #
-# ClawHub is the registry of record for the plugin — no git tag or GitHub
-# Release is cut here, and the published package carries the real commit SHA as
-# its provenance, so any version is traceable back to a commit.
+# Both the GitHub release artifact and ClawHub package carry the source commit
+# provenance. No files are stamped or committed back to the branch.
 #
-# A push that doesn't touch plugin/** never starts this workflow. Manual
-# dispatch from any ref runs the same flow, but only main publishes.
-#
-# Plugin tests run inline here so this stays the only thing that exercises the
-# plugin on main (workflow.yaml skips its plugin job on push-to-main).
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - 'plugin/**'
+  workflow_run:
+    workflows:
+      - Publish Clawbits OpenClaw Tools to ClawHub
+    types:
+      - completed
 
 permissions:
   contents: write # "Publish GitHub Release" creates the openclaw-plugin-v* tag + release on this repo
 
 concurrency:
-  group: publish-clawbits-${{ github.ref_name }}
+  group: publish-clawbits-channel-main
   cancel-in-progress: false
 
 jobs:
   publish-plugin:
     name: Publish plugin
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-24.04
+    env:
+      SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+      SOURCE_REF: refs/heads/${{ github.event.workflow_run.head_branch }}
     steps:
       - name: Checkout monorepo
         uses: actions/checkout@v7
@@ -52,11 +52,17 @@ jobs:
           # Full history so "Stamp auto version" can count commits touching plugin/.
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
 
       - name: Install plugin dependencies
         working-directory: plugin
@@ -107,10 +113,18 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          if [ "${{ github.ref_name }}" != "main" ]; then
+          if [ "${{ github.event.workflow_run.head_branch }}" != "main" ]; then
             echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Ref ${{ github.ref_name }} is not main; testing and staging only, nothing will be published."
+            echo "::notice::Source branch is not main; testing and staging only, nothing will be published."
             exit 0
+          fi
+          tools_versions="$(curl -fsS "https://clawhub.ai/api/v1/packages/clawbits-openclaw-tools/versions" 2>/dev/null || true)"
+          if [ -z "$tools_versions" ] || ! node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            if (!(data.items || []).some((item) => item.version === process.argv[1])) process.exit(1);
+          ' "$VERSION" <<<"$tools_versions"; then
+            echo "::error::Matching companion version $VERSION is not verified on ClawHub; refusing channel publish."
+            exit 1
           fi
           versions_json="$(curl -fsS "https://clawhub.ai/api/v1/packages/clawbits-openclaw-plugin/versions" 2>/dev/null || true)"
           already=false
@@ -139,10 +153,39 @@ jobs:
         if: steps.guard.outputs.publish == 'true'
         working-directory: plugin
         run: |
-          rm -rf ../publish/clawbits-openclaw-plugin
-          mkdir -p ../publish/clawbits-openclaw-plugin
-          cp -r dist src docs skills openclaw.plugin.json clawbits.config.example.json package.json ../publish/clawbits-openclaw-plugin/
+          set -euo pipefail
+          staged=../publish/clawbits-openclaw-plugin
+          node stage-channel.mjs "$staged"
+          test ! -e "$staged/src"
+          test ! -e "$staged/skills"
+          test ! -e "$staged/dist/tools-entry.js"
           echo "publish_path=publish/clawbits-openclaw-plugin" >> "$GITHUB_OUTPUT"
+
+      - name: Validate staged artifact against the floor and pinned OpenClaw SDKs
+        if: steps.guard.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          validation_root="$(mktemp -d)"
+          trap 'rm -rf "$validation_root"' EXIT
+          cp -R "${{ steps.pack.outputs.publish_path }}" "$validation_root/plugin"
+          cd "$validation_root/plugin"
+          sdk_versions="$(node -p "const o=require('./package.json').openclaw; [...new Set([o.compat.minGatewayVersion, o.build.openclawVersion])].join('\\n')")"
+          while read -r sdk_version; do
+            [ -n "$sdk_version" ] || continue
+            echo "::group::openclaw@${sdk_version}"
+            rm -rf node_modules
+            npm install --ignore-scripts --no-audit --no-fund --package-lock=false --no-save \
+              "openclaw@${sdk_version}"
+            # The CLI validator is defineToolPlugin-only. Importing executes
+            # defineChannelPluginEntry against this exact host SDK.
+            node --input-type=module - <<'NODE'
+            const entry = (await import('./dist/index.js')).default;
+            if (entry.id !== 'clawbits' || typeof entry.register !== 'function') {
+              throw new Error('invalid channel entry');
+            }
+            NODE
+            echo "::endgroup::"
+          done <<< "$sdk_versions"
 
       # The GitHub Release is cut BEFORE the ClawHub publish on purpose: the two
       # are independent distribution channels, so a registry-side failure (auth,
@@ -182,13 +225,13 @@ jobs:
             gh release create "$TAG" \
               --repo "${{ github.repository }}" \
               --latest=false \
-              --target "${{ github.sha }}" \
+              --target "$SOURCE_SHA" \
               --title "Clawbits OpenClaw plugin v$VERSION" \
               --notes "OpenClaw channel plugin bridging an agent to its Clawbits organization.
 
           Install from ClawHub:
           \`\`\`
-          openclaw plugins install clawhub:clawbits-openclaw-plugin --pin --acknowledge-clawhub-risk
+          openclaw plugins install clawhub:clawbits-openclaw-plugin --pin
           \`\`\`
           Or install the attached tarball directly: extract it and run \`openclaw plugins install <dir>\`."
           fi
@@ -237,8 +280,8 @@ jobs:
           if bunx --bun clawhub@latest package publish "${{ steps.pack.outputs.publish_path }}" \
               --family code-plugin \
               --source-repo "${{ github.repository }}" \
-              --source-commit "${{ github.sha }}" \
-              --source-ref "${{ github.ref }}"; then
+              --source-commit "$SOURCE_SHA" \
+              --source-ref "$SOURCE_REF"; then
             echo "Published $VERSION"
             exit 0
           fi

--- a/.github/workflows/publish-clawhub-plugin.yaml
+++ b/.github/workflows/publish-clawhub-plugin.yaml
@@ -139,9 +139,27 @@ jobs:
         if: steps.guard.outputs.publish == 'true'
         working-directory: plugin
         run: |
-          rm -rf ../publish/clawbits-openclaw-plugin
-          mkdir -p ../publish/clawbits-openclaw-plugin
-          cp -r dist src docs skills openclaw.plugin.json clawbits.config.example.json package.json ../publish/clawbits-openclaw-plugin/
+          set -euo pipefail
+          staged=../publish/clawbits-openclaw-plugin
+          rm -rf "$staged"
+          mkdir -p "$staged"
+          cp -r dist src docs skills openclaw.plugin.json clawbits.config.example.json package.json "$staged/"
+          # Prune what belongs to the tools package or to the build only. Both
+          # share this source tree but neither is part of the channel artifact,
+          # and the manifest loads only ./src/index.ts + ./dist/index.js, so
+          # nothing here is reachable at runtime:
+          #   tools-entry.*  -> the clawbits-openclaw-tools entry; it imports
+          #                     `typebox`, which the channel package does not
+          #                     declare as a runtime dependency, so shipping it
+          #                     puts an unresolvable bare import in the artifact.
+          #   test-stubs/    -> typecheck-only fakes for `openclaw/plugin-sdk/*`
+          #                     (tsconfig `paths`); tsconfig.json is not staged,
+          #                     so they are dead weight that merely looks like a
+          #                     counterfeit copy of the real SDK.
+          rm -rf "$staged/src/test-stubs" "$staged/dist/test-stubs"
+          rm -f "$staged/src/tools-entry.ts" \
+                "$staged/dist/tools-entry.js" \
+                "$staged/dist/tools-entry.d.ts"
           echo "publish_path=publish/clawbits-openclaw-plugin" >> "$GITHUB_OUTPUT"
 
       # The GitHub Release is cut BEFORE the ClawHub publish on purpose: the two
@@ -188,7 +206,7 @@ jobs:
 
           Install from ClawHub:
           \`\`\`
-          openclaw plugins install clawhub:clawbits-openclaw-plugin --pin --acknowledge-clawhub-risk
+          openclaw plugins install clawhub:clawbits-openclaw-plugin --pin
           \`\`\`
           Or install the attached tarball directly: extract it and run \`openclaw plugins install <dir>\`."
           fi

--- a/.github/workflows/publish-clawhub-tools.yaml
+++ b/.github/workflows/publish-clawhub-tools.yaml
@@ -1,0 +1,350 @@
+name: Publish Clawbits OpenClaw Tools to ClawHub
+
+# First half of the coordinated release. This standalone companion is built,
+# validated, published, and registry-verified before its successful workflow
+# completion is allowed to trigger the slim channel publication.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'plugin/**'
+      - '.github/workflows/publish-clawhub-tools.yaml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-clawbits-tools-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-tools:
+    name: Publish tools plugin
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout monorepo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Bun runs the build and tests, but the stamping, staging, validation and
+      # registry-check steps all shell out to `node`/`npm`, so the runner's
+      # default Node would silently decide their behaviour. Pin it to match the
+      # `engines.node: ">=22"` this package publishes. It matters most at the
+      # validation step: `openclaw plugins build/validate` executes the compiled
+      # artifact, and dist/tools-entry.js calls `AbortSignal.any`, which does not
+      # exist before Node 20.3 — on an older runner that would fail as a bogus
+      # plugin error rather than an environment one.
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        working-directory: plugin
+        run: bun --bun run typecheck
+
+      - name: Run plugin tests
+        working-directory: plugin
+        run: bun run test
+
+      # Keep the tools and channel versions aligned. ClawBitsClient sends the
+      # package version in X-Clawbits-Plugin-Version, so both artifacts use the
+      # same major/minor and the same plugin/ commit-count patch.
+      - name: Stamp auto version (patch = plugin commit count)
+        id: version
+        working-directory: plugin
+        run: |
+          set -euo pipefail
+          base="$(node -p "JSON.parse(require('fs').readFileSync('package.tools.json','utf8')).version.split('.').slice(0,2).join('.')")"
+          patch="$(git rev-list --count HEAD -- .)"
+          version="${base}.${patch}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Tools plugin version: $version"
+          node - "$version" <<'NODE'
+          const fs = require('node:fs');
+          const version = process.argv[2];
+          for (const path of ['package.tools.json', 'openclaw.tools.plugin.json']) {
+            const json = JSON.parse(fs.readFileSync(path, 'utf8'));
+            json.version = version;
+            if (json.openclaw?.version) json.openclaw.version = version;
+            fs.writeFileSync(path, JSON.stringify(json, null, 2) + '\n');
+          }
+          NODE
+
+      - name: Decide whether to publish
+        id: guard
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Ref ${{ github.ref_name }} is not main; testing only."
+            exit 0
+          fi
+          versions_json="$(curl -fsS "https://clawhub.ai/api/v1/packages/clawbits-openclaw-tools/versions" 2>/dev/null || true)"
+          already=false
+          if [ -n "$versions_json" ]; then
+            already="$(node -e '
+              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              const versions = (data.items || []).map((item) => item.version);
+              console.log(versions.includes(process.argv[1]) ? "true" : "false");
+            ' "$VERSION" <<<"$versions_json")"
+          fi
+          if [ "$already" = "true" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::clawbits-openclaw-tools@$VERSION already exists; skipping."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build shared source tree
+        if: steps.guard.outputs.publish == 'true'
+        working-directory: plugin
+        run: bun --bun run build
+
+      - name: Stage standalone tools artifact
+        id: pack
+        if: steps.guard.outputs.publish == 'true'
+        working-directory: plugin
+        run: |
+          set -euo pipefail
+          target="../publish/clawbits-openclaw-tools"
+          node stage-tools.mjs "$target"
+          test ! -e "$target/src"
+          test ! -e "$target/dist/index.js"
+          test ! -e "$target/dist/gateway-adapter.js"
+          test -e "$target/skills"
+          node - "$target" <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const root = process.argv[2];
+          const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+          const manifest = JSON.parse(fs.readFileSync(path.join(root, 'openclaw.plugin.json'), 'utf8'));
+          const expected = './dist/tools-entry.js';
+          if (pkg.name !== 'clawbits-openclaw-tools') throw new Error('wrong package name');
+          if (pkg.openclaw?.id !== 'clawbits-tools') throw new Error('wrong plugin id');
+          if (pkg.openclaw?.extensions?.length !== 1 || pkg.openclaw.extensions[0] !== expected) {
+            throw new Error('tools package must load only dist/tools-entry.js');
+          }
+          if (!fs.existsSync(path.join(root, expected))) throw new Error('compiled tools entry missing');
+          const tools = manifest.contracts?.tools || [];
+          if (tools.length === 0) throw new Error('manifest declares no tools');
+          for (const name of tools) {
+            if (manifest.toolMetadata?.[name]?.optional !== true) {
+              throw new Error(`tool ${name} must be optional`);
+            }
+          }
+          NODE
+          echo "publish_path=publish/clawbits-openclaw-tools" >> "$GITHUB_OUTPUT"
+          find "$target" -type f | sort
+
+      # Validate against every distinct OpenClaw version the package claims to
+      # support: the compat floor AND the SDK it was built against (2026.6.10
+      # and 2026.6.33 today, so this runs twice).
+      #
+      # The floor stays at 2026.6.10 to match the channel plugin and the
+      # OpenClaw tag Reef's runtime image pins (see
+      # reef/images/openclaw-runtime/Dockerfile) — both packages have to install
+      # into that same agent image. Because this step exercises the floor rather
+      # than trusting it, an artifact that can no longer load on the oldest
+      # supported host fails the release instead of shipping a false claim.
+      - name: Validate staged artifact against the floor and pinned OpenClaw SDKs
+        if: steps.guard.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          validation_root="$(mktemp -d)"
+          trap 'rm -rf "$validation_root"' EXIT
+          cp -R "${{ steps.pack.outputs.publish_path }}" "$validation_root/plugin"
+          cd "$validation_root/plugin"
+          # Newline-separated + `read`, not word-splitting on an unquoted
+          # expansion: the latter silently degrades to a single iteration
+          # carrying both versions under shells that don't split (zsh), which
+          # would look like a pass while validating nothing.
+          sdk_versions="$(node -p "const o=require('./package.json').openclaw; [...new Set([o.compat.minGatewayVersion, o.build.openclawVersion])].join('\n')")"
+          echo "Validating against:"
+          echo "$sdk_versions"
+          while read -r sdk_version; do
+            [ -n "$sdk_version" ] || continue
+            echo "::group::openclaw@${sdk_version}"
+            rm -rf node_modules
+            npm install --ignore-scripts --no-audit --no-fund --package-lock=false --no-save \
+              "openclaw@${sdk_version}"
+            # `plugins validate --entry` is defineToolPlugin-only. This is a
+            # mixed definePluginEntry, so load it against the real SDK and
+            # exercise tool discovery instead.
+            node --input-type=module - <<'NODE'
+            const entry = (await import('./dist/tools-entry.js')).default;
+            const names = [];
+            entry.register({
+              registrationMode: 'tool-discovery',
+              config: {},
+              logger: {},
+              runtime: {},
+              registerTool(tool, options) {
+                if (options?.optional !== true) throw new Error(`${tool.name} is not optional`);
+                names.push(tool.name);
+              },
+              on() {},
+            });
+            if (names.length !== 7) throw new Error(`expected 7 tools, got ${names.length}`);
+
+            // Prove companion-owned email dispatch through this SDK's public
+            // non-channel plugin runtime surface.
+            const { dispatchInboundEmail } = await import('./dist/email-adapter.js');
+            let dispatched;
+            const channelRuntime = {
+              routing: { resolveAgentRoute: () => ({
+                agentId: 'agent-1', accountId: 'default', sessionKey: 'agent:main:main',
+              }) },
+              session: {
+                resolveStorePath: () => '/tmp/clawbits-sdk-email-smoke.json',
+                readSessionUpdatedAt: () => undefined,
+                recordInboundSession: async () => {},
+              },
+              reply: {
+                resolveEnvelopeFormatOptions: () => ({}),
+                formatAgentEnvelope: ({ body }) => body,
+                finalizeInboundContext: (input) => input,
+                dispatchReplyWithBufferedBlockDispatcher: async ({ ctx }) => { dispatched = ctx; },
+              },
+            };
+            await dispatchInboundEmail({
+              cfg: { channels: { clawbits: {} } },
+              accountId: 'default',
+              account: {
+                accountId: 'default', enabled: true, configured: true,
+                endpoint: 'https://example.invalid', agentId: 'agent-1', apiKey: 'key',
+                channelId: 'channel-1', knownAnswers: {}, interAgentMode: false,
+                interAgentMessageLimit: 10, groupChannelShimmer: true,
+                channelContextBacklog: 100, alivePingMs: 0, emailEnabled: true,
+                emailPollIntervalMs: 60000, config: {},
+              },
+              channelRuntime,
+              log: {},
+            }, {
+              accountId: 'default', uid: 1, fromAddr: 'owner@example.test',
+              toAddr: 'agent@example.test', subject: 'SDK smoke', date: '',
+              bodyText: 'hello', attachments: [], headers: {},
+            });
+            if (dispatched?.EmailUid !== 1) {
+              throw new Error('email did not dispatch through public runtime');
+            }
+            NODE
+            echo "::endgroup::"
+          done <<< "$sdk_versions"
+
+      - name: Package GitHub release tarball
+        id: tarball
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          asset="clawbits-openclaw-tools-${VERSION}.tgz"
+          tar -czf "$asset" -C publish clawbits-openclaw-tools
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub Release
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          ASSET: ${{ steps.tarball.outputs.asset }}
+        run: |
+          set -euo pipefail
+          tag="openclaw-tools-v${VERSION}"
+          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --repo "${{ github.repository }}" \
+              --latest=false \
+              --target "${{ github.sha }}" \
+              --title "Clawbits OpenClaw tools v$VERSION" \
+              --notes "Optional tools plus Clawbits cron, email, usage, and skills services.
+
+          Install before upgrading the channel plugin:
+          \`\`\`
+          openclaw plugins install clawhub:clawbits-openclaw-tools --pin
+          \`\`\`"
+          fi
+          gh release upload "$tag" "$ASSET" --repo "${{ github.repository }}" --clobber
+
+      - name: Authenticate ClawHub CLI
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          CLAWHUB_API_TOKEN: ${{ secrets.CLAWHUB_API_TOKEN }}
+        run: |
+          if [ -z "$CLAWHUB_API_TOKEN" ]; then
+            echo "::error::Missing required secret CLAWHUB_API_TOKEN"
+            exit 1
+          fi
+          bunx --bun clawhub@latest login --token "$CLAWHUB_API_TOKEN" --no-browser
+
+      - name: Verify ClawHub authentication
+        if: steps.guard.outputs.publish == 'true'
+        run: bunx --bun clawhub@latest whoami
+
+      - name: Publish package to ClawHub
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -uo pipefail
+          if bunx --bun clawhub@latest package publish "${{ steps.pack.outputs.publish_path }}" \
+              --family code-plugin \
+              --source-repo "${{ github.repository }}" \
+              --source-commit "${{ github.sha }}" \
+              --source-ref "${{ github.ref }}"; then
+            echo "Published clawbits-openclaw-tools@$VERSION"
+            exit 0
+          fi
+
+          echo "::warning::publish exited non-zero; checking whether $VERSION landed"
+          versions_json="$(curl -fsS "https://clawhub.ai/api/v1/packages/clawbits-openclaw-tools/versions" || true)"
+          if [ -z "$versions_json" ]; then
+            echo "::error::publish failed and registry verification was unavailable"
+            exit 1
+          fi
+          landed="$(node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const versions = (data.items || []).map((item) => item.version);
+            console.log(versions.includes(process.argv[1]) ? "true" : "false");
+          ' "$VERSION" <<<"$versions_json")"
+          if [ "$landed" = "true" ]; then
+            echo "::notice::$VERSION exists despite the non-zero publish exit; treating as success."
+            exit 0
+          fi
+          echo "::error::publish failed and $VERSION is not on ClawHub"
+          exit 1
+
+      - name: Verify companion release on ClawHub
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5 6; do
+            versions_json="$(curl -fsS "https://clawhub.ai/api/v1/packages/clawbits-openclaw-tools/versions" || true)"
+            if [ -n "$versions_json" ] && node -e '
+              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              if (!(data.items || []).some((item) => item.version === process.argv[1])) process.exit(1);
+            ' "$VERSION" <<<"$versions_json"; then
+              echo "Verified clawbits-openclaw-tools@$VERSION"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Companion $VERSION was not visible on ClawHub after publish"
+          exit 1

--- a/.github/workflows/publish-clawhub-tools.yaml
+++ b/.github/workflows/publish-clawhub-tools.yaml
@@ -1,0 +1,269 @@
+name: Publish Clawbits OpenClaw Tools to ClawHub
+
+# Separate artifact from the channel plugin, built from the same plugin/ source
+# tree. Shared source changes intentionally release both packages so each
+# installed extension carries a standalone, current copy of the HTTP/config
+# modules. This workflow only publishes after a push to main; pull requests use
+# workflow.yaml's plugin-test job.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'plugin/**'
+      - '.github/workflows/publish-clawhub-tools.yaml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-clawbits-tools-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-tools:
+    name: Publish tools plugin
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout monorepo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Bun runs the build and tests, but the stamping, staging, validation and
+      # registry-check steps all shell out to `node`/`npm`, so the runner's
+      # default Node would silently decide their behaviour. Pin it to match the
+      # `engines.node: ">=22"` this package publishes. It matters most at the
+      # validation step: `openclaw plugins build/validate` executes the compiled
+      # artifact, and dist/tools-entry.js calls `AbortSignal.any`, which does not
+      # exist before Node 20.3 — on an older runner that would fail as a bogus
+      # plugin error rather than an environment one.
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        working-directory: plugin
+        run: bun --bun run typecheck
+
+      - name: Run plugin tests
+        working-directory: plugin
+        run: bun run test
+
+      # Keep the tools and channel versions aligned. ClawBitsClient sends the
+      # package version in X-Clawbits-Plugin-Version, so both artifacts use the
+      # same major/minor and the same plugin/ commit-count patch.
+      - name: Stamp auto version (patch = plugin commit count)
+        id: version
+        working-directory: plugin
+        run: |
+          set -euo pipefail
+          base="$(node -p "JSON.parse(require('fs').readFileSync('package.tools.json','utf8')).version.split('.').slice(0,2).join('.')")"
+          patch="$(git rev-list --count HEAD -- .)"
+          version="${base}.${patch}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Tools plugin version: $version"
+          node - "$version" <<'NODE'
+          const fs = require('node:fs');
+          const version = process.argv[2];
+          for (const path of ['package.tools.json', 'openclaw.tools.plugin.json']) {
+            const json = JSON.parse(fs.readFileSync(path, 'utf8'));
+            json.version = version;
+            if (json.openclaw?.version) json.openclaw.version = version;
+            fs.writeFileSync(path, JSON.stringify(json, null, 2) + '\n');
+          }
+          NODE
+
+      - name: Decide whether to publish
+        id: guard
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Ref ${{ github.ref_name }} is not main; testing only."
+            exit 0
+          fi
+          versions_json="$(curl -fsS "https://clawhub.ai/api/v1/packages/clawbits-openclaw-tools/versions" 2>/dev/null || true)"
+          already=false
+          if [ -n "$versions_json" ]; then
+            already="$(node -e '
+              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              const versions = (data.items || []).map((item) => item.version);
+              console.log(versions.includes(process.argv[1]) ? "true" : "false");
+            ' "$VERSION" <<<"$versions_json")"
+          fi
+          if [ "$already" = "true" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::clawbits-openclaw-tools@$VERSION already exists; skipping."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build shared source tree
+        if: steps.guard.outputs.publish == 'true'
+        working-directory: plugin
+        run: bun --bun run build
+
+      - name: Stage standalone tools artifact
+        id: pack
+        if: steps.guard.outputs.publish == 'true'
+        working-directory: plugin
+        run: |
+          set -euo pipefail
+          target="../publish/clawbits-openclaw-tools"
+          node stage-tools.mjs "$target"
+          node - "$target" <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const root = process.argv[2];
+          const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+          const manifest = JSON.parse(fs.readFileSync(path.join(root, 'openclaw.plugin.json'), 'utf8'));
+          const expected = './dist/tools-entry.js';
+          if (pkg.name !== 'clawbits-openclaw-tools') throw new Error('wrong package name');
+          if (pkg.openclaw?.id !== 'clawbits-tools') throw new Error('wrong plugin id');
+          if (pkg.openclaw?.extensions?.length !== 1 || pkg.openclaw.extensions[0] !== expected) {
+            throw new Error('tools package must load only dist/tools-entry.js');
+          }
+          if (!fs.existsSync(path.join(root, expected))) throw new Error('compiled tools entry missing');
+          const tools = manifest.contracts?.tools || [];
+          if (tools.length === 0) throw new Error('manifest declares no tools');
+          for (const name of tools) {
+            if (manifest.toolMetadata?.[name]?.optional !== true) {
+              throw new Error(`tool ${name} must be optional`);
+            }
+          }
+          NODE
+          echo "publish_path=publish/clawbits-openclaw-tools" >> "$GITHUB_OUTPUT"
+          find "$target" -type f | sort
+
+      # Validate against every distinct OpenClaw version the package claims to
+      # support: the compat floor AND the SDK it was built against (2026.6.10
+      # and 2026.6.33 today, so this runs twice).
+      #
+      # The floor stays at 2026.6.10 to match the channel plugin and the
+      # OpenClaw tag Reef's runtime image pins (see
+      # reef/images/openclaw-runtime/Dockerfile) — both packages have to install
+      # into that same agent image. Because this step exercises the floor rather
+      # than trusting it, an artifact that can no longer load on the oldest
+      # supported host fails the release instead of shipping a false claim.
+      - name: Validate staged artifact against the floor and pinned OpenClaw SDKs
+        if: steps.guard.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          validation_root="$(mktemp -d)"
+          trap 'rm -rf "$validation_root"' EXIT
+          cp -R "${{ steps.pack.outputs.publish_path }}" "$validation_root/plugin"
+          cd "$validation_root/plugin"
+          # Newline-separated + `read`, not word-splitting on an unquoted
+          # expansion: the latter silently degrades to a single iteration
+          # carrying both versions under shells that don't split (zsh), which
+          # would look like a pass while validating nothing.
+          sdk_versions="$(node -p "const o=require('./package.json').openclaw; [...new Set([o.compat.minGatewayVersion, o.build.openclawVersion])].join('\n')")"
+          echo "Validating against:"
+          echo "$sdk_versions"
+          while read -r sdk_version; do
+            [ -n "$sdk_version" ] || continue
+            echo "::group::openclaw@${sdk_version}"
+            rm -rf node_modules
+            npm install --ignore-scripts --no-audit --no-fund --package-lock=false --no-save \
+              "openclaw@${sdk_version}"
+            ./node_modules/.bin/openclaw plugins build --entry ./dist/tools-entry.js --check
+            ./node_modules/.bin/openclaw plugins validate --entry ./dist/tools-entry.js
+            echo "::endgroup::"
+          done <<< "$sdk_versions"
+
+      - name: Package GitHub release tarball
+        id: tarball
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          asset="clawbits-openclaw-tools-${VERSION}.tgz"
+          tar -czf "$asset" -C publish clawbits-openclaw-tools
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub Release
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          ASSET: ${{ steps.tarball.outputs.asset }}
+        run: |
+          set -euo pipefail
+          tag="openclaw-tools-v${VERSION}"
+          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --repo "${{ github.repository }}" \
+              --latest=false \
+              --target "${{ github.sha }}" \
+              --title "Clawbits OpenClaw tools v$VERSION" \
+              --notes "Optional OpenClaw tools for Clawbits channels, email, and agent information.
+
+          Install after the channel plugin:
+          \`\`\`
+          openclaw plugins install clawhub:clawbits-openclaw-tools --pin
+          \`\`\`"
+          fi
+          gh release upload "$tag" "$ASSET" --repo "${{ github.repository }}" --clobber
+
+      - name: Authenticate ClawHub CLI
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          CLAWHUB_API_TOKEN: ${{ secrets.CLAWHUB_API_TOKEN }}
+        run: |
+          if [ -z "$CLAWHUB_API_TOKEN" ]; then
+            echo "::error::Missing required secret CLAWHUB_API_TOKEN"
+            exit 1
+          fi
+          bunx --bun clawhub@latest login --token "$CLAWHUB_API_TOKEN" --no-browser
+
+      - name: Verify ClawHub authentication
+        if: steps.guard.outputs.publish == 'true'
+        run: bunx --bun clawhub@latest whoami
+
+      - name: Publish package to ClawHub
+        if: steps.guard.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -uo pipefail
+          if bunx --bun clawhub@latest package publish "${{ steps.pack.outputs.publish_path }}" \
+              --family code-plugin \
+              --source-repo "${{ github.repository }}" \
+              --source-commit "${{ github.sha }}" \
+              --source-ref "${{ github.ref }}"; then
+            echo "Published clawbits-openclaw-tools@$VERSION"
+            exit 0
+          fi
+
+          echo "::warning::publish exited non-zero; checking whether $VERSION landed"
+          versions_json="$(curl -fsS "https://clawhub.ai/api/v1/packages/clawbits-openclaw-tools/versions" || true)"
+          if [ -z "$versions_json" ]; then
+            echo "::error::publish failed and registry verification was unavailable"
+            exit 1
+          fi
+          landed="$(node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const versions = (data.items || []).map((item) => item.version);
+            console.log(versions.includes(process.argv[1]) ? "true" : "false");
+          ' "$VERSION" <<<"$versions_json")"
+          if [ "$landed" = "true" ]; then
+            echo "::notice::$VERSION exists despite the non-zero publish exit; treating as success."
+            exit 0
+          fi
+          echo "::error::publish failed and $VERSION is not on ClawHub"
+          exit 1

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,14 @@
+# Clawbits OpenClaw Channel
+
+OpenClaw chat channel for Clawbits.
+
+This package owns chat polling, outbound messages, attachments, reactions,
+setup/configuration, presence/liveness, and live reply activity.
+
+Cron reconciliation, email, usage reporting, skills synchronization, and
+optional agent tools are in the separately installed
+`clawbits-openclaw-tools` companion package. Both packages read the existing
+account credentials under `channels.clawbits.*`; no new signup is required.
+
+See [`docs/SPLIT_MIGRATION.md`](docs/SPLIT_MIGRATION.md) before upgrading an
+installation older than `0.17`.

--- a/plugin/README.tools.md
+++ b/plugin/README.tools.md
@@ -1,0 +1,44 @@
+# Clawbits OpenClaw Tools
+
+Optional OpenClaw tools for reading Clawbits channels, email, and agent
+information.
+
+This plugin reuses account configuration written by the Clawbits channel plugin:
+
+```text
+channels.clawbits.accounts.<accountId>.*
+```
+
+Install both packages:
+
+```sh
+openclaw plugins install clawhub:clawbits-openclaw-plugin --pin
+openclaw plugins install clawhub:clawbits-openclaw-tools --pin
+```
+
+The tools are optional. Add the required tool names to `tools.alsoAllow` before
+using them.
+
+## Tools
+
+- `clawbits_channels_list`
+- `clawbits_channel_members`
+- `clawbits_email_inbox`
+- `clawbits_email_get` (marks the fetched message read)
+- `clawbits_agent_info`
+
+The package has no runtime import from the installed channel extension. Both
+artifacts carry their own compiled copy of the shared HTTP/config modules.
+
+## Compatibility
+
+Requires OpenClaw `>=2026.6.10` — the same floor as the channel plugin, and the
+OpenClaw tag Reef's runtime image pins
+(`reef/images/openclaw-runtime/Dockerfile`), so both packages install into the
+same agent image.
+
+The floor is exercised, not just asserted: every publish validates the built
+artifact against both the floor and the SDK it was compiled against (see
+`.github/workflows/publish-clawhub-tools.yaml`). Raise it only if that
+validation actually fails on the older SDK, and check Reef's pin first — a floor
+above Reef's tag makes this package uninstallable there.

--- a/plugin/README.tools.md
+++ b/plugin/README.tools.md
@@ -1,0 +1,51 @@
+# Clawbits OpenClaw Tools
+
+Optional OpenClaw tools plus Clawbits cron, email, usage, and skills services.
+
+This plugin reuses account configuration written by the Clawbits channel plugin:
+
+```text
+channels.clawbits.accounts.<accountId>.*
+```
+
+Install both packages:
+
+```sh
+openclaw plugins install clawhub:clawbits-openclaw-plugin --pin
+openclaw plugins install clawhub:clawbits-openclaw-tools --pin
+openclaw config set channels.clawbits.serviceOwner tools
+```
+
+For an existing pre-0.17 channel, use the safe order in the channel package's
+`docs/SPLIT_MIGRATION.md` instead.
+
+The tools are optional. Add the required tool names to `tools.alsoAllow` before
+using them. Background services start only when
+`channels.clawbits.serviceOwner=tools` and a compatible slim channel plugin is
+active.
+
+## Tools
+
+- `clawbits_channels_list`
+- `clawbits_channel_members`
+- `clawbits_email_inbox`
+- `clawbits_email_get` (marks the fetched message read)
+- `clawbits_agent_info`
+- `clawbits_email_send`
+- `clawbits_agent_description_update`
+
+The package has no runtime import from the installed channel extension. Both
+artifacts carry their own compiled copy of the shared HTTP/config modules.
+
+## Compatibility
+
+Requires OpenClaw `>=2026.6.10` — the same floor as the channel plugin, and the
+OpenClaw tag Reef's runtime image pins
+(`reef/images/openclaw-runtime/Dockerfile`), so both packages install into the
+same agent image.
+
+The floor is exercised, not just asserted: every publish validates the built
+artifact against both the floor and the SDK it was compiled against (see
+`.github/workflows/publish-clawhub-tools.yaml`). Raise it only if that
+validation actually fails on the older SDK, and check Reef's pin first — a floor
+above Reef's tag makes this package uninstallable there.

--- a/plugin/bun.lock
+++ b/plugin/bun.lock
@@ -6,12 +6,15 @@
       "name": "clawbits-openclaw-plugin",
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "typebox": "^1.1.38",
         "typescript": "^5.0.0",
       },
     },
   },
   "packages": {
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "typebox": ["typebox@1.3.19", "", {}, "sha512-OGhGi3JkTMol9QW8Bc6tgSD4ghV8v5WubAi1XeYnlxdocHvgS7TQJ8FcFZrQhVhigQU0z7bRFAEsZ+wpkRdCfg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/plugin/docs/SELF_UPDATE.md
+++ b/plugin/docs/SELF_UPDATE.md
@@ -1,5 +1,9 @@
 # Updating the Clawbits plugin
 
+> **Pre-0.17 installations:** do not upgrade the channel package alone. Follow
+> [SPLIT_MIGRATION.md](SPLIT_MIGRATION.md) to install the companion and hand off
+> services before installing the slim channel.
+
 Agents are installed as a **pinned remote ClawHub package**:
 
 ```bash

--- a/plugin/docs/SPLIT_MIGRATION.md
+++ b/plugin/docs/SPLIT_MIGRATION.md
@@ -1,0 +1,63 @@
+# Channel/companion migration
+
+Version `0.17` splits Clawbits into two independently installed OpenClaw
+plugins:
+
+- `clawbits-openclaw-plugin` (`clawbits`): chat channel only.
+- `clawbits-openclaw-tools` (`clawbits-tools`): optional tools plus cron,
+  email, usage, and skills services.
+
+Credentials and account settings stay under `channels.clawbits.*`. Do not run
+signup again.
+
+## Existing installation
+
+Migrate in this order. Do not upgrade the channel first.
+
+```sh
+openclaw plugins install clawhub:clawbits-openclaw-tools --pin
+openclaw config set channels.clawbits.serviceOwner tools
+openclaw plugins install clawhub:clawbits-openclaw-plugin --pin --force
+```
+
+OpenClaw may restart the managed Gateway after an install. If so, reconnect and
+run the next command. The sequence is safe:
+
+1. The companion stays idle beside a pre-split channel because no compatible
+   slim-channel runtime marker exists.
+2. A pre-split channel ignores `serviceOwner` and keeps services running.
+3. The final channel upgrade removes legacy services and publishes the marker;
+   the companion then becomes their sole owner.
+
+Optional tools also require explicit entries in `tools.alsoAllow`:
+
+- `clawbits_channels_list`
+- `clawbits_channel_members`
+- `clawbits_email_inbox`
+- `clawbits_email_get`
+- `clawbits_agent_info`
+- `clawbits_email_send`
+- `clawbits_agent_description_update`
+
+## New installation
+
+Install and configure the channel first, then install the companion, set
+`channels.clawbits.serviceOwner=tools`, and restart the Gateway.
+
+## State and rollback
+
+The split preserves cron identifiers, skills ownership markers, account
+configuration, and email progress. Email state migrates once from legacy
+`clawbits-channel-watermarks.json` data into companion-owned
+`clawbits-email-state.json`.
+
+Before upgrading the slim channel, rollback is simply removing the companion
+or setting `serviceOwner=channel`. After upgrading the slim channel, restore a
+pre-`0.17` channel before setting `serviceOwner=channel`; the slim channel does
+not contain legacy services.
+
+## Reef
+
+Do not roll Reef agents one package at a time. Build one runtime image with both
+matching package versions and `serviceOwner=tools`, then recreate agents so the
+old VM stops before the replacement Gateway starts.

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -1,12 +1,9 @@
 {
   "id": "clawbits",
   "name": "Clawbits Human Channel",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "channels": [
     "clawbits"
-  ],
-  "skills": [
-    "./skills"
   ],
   "configSchema": {
     "type": "object",
@@ -27,6 +24,15 @@
           },
           "enabled": {
             "type": "boolean"
+          },
+          "serviceOwner": {
+            "type": "string",
+            "enum": [
+              "channel",
+              "tools"
+            ],
+            "default": "channel",
+            "description": "Owner of Clawbits cron, email, usage, and skills services. Set to tools only after installing a compatible clawbits-tools plugin."
           },
           "endpoint": {
             "type": "string",
@@ -226,6 +232,9 @@
         },
         "agentId": {
           "label": "Agent ID"
+        },
+        "serviceOwner": {
+          "label": "Background service owner"
         },
         "emailEnabled": {
           "label": "Email integration enabled"

--- a/plugin/openclaw.tools.plugin.json
+++ b/plugin/openclaw.tools.plugin.json
@@ -1,0 +1,54 @@
+{
+  "id": "clawbits-tools",
+  "name": "Clawbits Tools & Services",
+  "description": "Clawbits tools and companion background services.",
+  "version": "0.17.0",
+  "requiresPlugins": [
+    "clawbits"
+  ],
+  "skills": [
+    "./skills"
+  ],
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  },
+  "contracts": {
+    "tools": [
+      "clawbits_channels_list",
+      "clawbits_channel_members",
+      "clawbits_email_inbox",
+      "clawbits_email_get",
+      "clawbits_agent_info",
+      "clawbits_email_send",
+      "clawbits_agent_description_update"
+    ]
+  },
+  "toolMetadata": {
+    "clawbits_channels_list": {
+      "optional": true
+    },
+    "clawbits_channel_members": {
+      "optional": true
+    },
+    "clawbits_email_inbox": {
+      "optional": true
+    },
+    "clawbits_email_get": {
+      "optional": true
+    },
+    "clawbits_agent_info": {
+      "optional": true
+    },
+    "clawbits_email_send": {
+      "optional": true
+    },
+    "clawbits_agent_description_update": {
+      "optional": true
+    }
+  }
+}

--- a/plugin/openclaw.tools.plugin.json
+++ b/plugin/openclaw.tools.plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "clawbits-tools",
+  "name": "Clawbits Tools",
+  "description": "Read Clawbits channels, email, and agent information.",
+  "version": "0.16.0",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  },
+  "contracts": {
+    "tools": [
+      "clawbits_channels_list",
+      "clawbits_channel_members",
+      "clawbits_email_inbox",
+      "clawbits_email_get",
+      "clawbits_agent_info"
+    ]
+  },
+  "toolMetadata": {
+    "clawbits_channels_list": {
+      "optional": true
+    },
+    "clawbits_channel_members": {
+      "optional": true
+    },
+    "clawbits_email_inbox": {
+      "optional": true
+    },
+    "clawbits_email_get": {
+      "optional": true
+    },
+    "clawbits_agent_info": {
+      "optional": true
+    }
+  }
+}

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "clawbits-openclaw-plugin",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawbits-openclaw-plugin",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "typebox": "^1.1.38",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -24,6 +25,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.19",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.19.tgz",
+      "integrity": "sha512-OGhGi3JkTMol9QW8Bc6tgSD4ghV8v5WubAi1XeYnlxdocHvgS7TQJ8FcFZrQhVhigQU0z7bRFAEsZ+wpkRdCfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "clawbits-openclaw-plugin",
-  "version": "0.15.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawbits-openclaw-plugin",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "typebox": "^1.1.38",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -24,6 +25,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.19",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.19.tgz",
+      "integrity": "sha512-OGhGi3JkTMol9QW8Bc6tgSD4ghV8v5WubAi1XeYnlxdocHvgS7TQJ8FcFZrQhVhigQU0z7bRFAEsZ+wpkRdCfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,15 +1,13 @@
 {
   "name": "clawbits-openclaw-plugin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "OpenClaw channel plugin: bridges an agent to its Clawbits organization via the Clawbits Mattermost surface.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
-    "src",
     "docs",
-    "skills",
     "openclaw.plugin.json",
     "clawbits.config.example.json"
   ],
@@ -19,19 +17,16 @@
   "openclaw": {
     "id": "clawbits",
     "name": "Clawbits Human Channel",
-    "version": "0.16.0",
-    "entry": "./src/index.ts",
+    "version": "0.17.0",
+    "entry": "./dist/index.js",
     "extensions": [
-      "./src/index.ts"
+      "./dist/index.js"
     ],
     "runtimeExtensions": [
       "./dist/index.js"
     ],
     "channels": [
       "clawbits"
-    ],
-    "skills": [
-      "./skills"
     ],
     "compat": {
       "pluginApi": ">=2026.6.10",
@@ -66,11 +61,12 @@
   "scripts": {
     "start": "bun src/index.ts",
     "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.test.json",
     "test": "bun test"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "typebox": "^1.1.38",
     "typescript": "^5.0.0"
   }
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -66,11 +66,12 @@
   "scripts": {
     "start": "bun src/index.ts",
     "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.test.json",
     "test": "bun test"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "typebox": "^1.1.38",
     "typescript": "^5.0.0"
   }
 }

--- a/plugin/package.tools.json
+++ b/plugin/package.tools.json
@@ -1,0 +1,47 @@
+{
+  "name": "clawbits-openclaw-tools",
+  "version": "0.16.0",
+  "description": "OpenClaw tools for reading Clawbits channels, email, and agent information.",
+  "type": "module",
+  "main": "dist/tools-entry.js",
+  "types": "dist/tools-entry.d.ts",
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.6.10"
+  },
+  "dependencies": {
+    "typebox": "^1.1.38"
+  },
+  "openclaw": {
+    "id": "clawbits-tools",
+    "name": "Clawbits Tools",
+    "version": "0.16.0",
+    "entry": "./dist/tools-entry.js",
+    "extensions": [
+      "./dist/tools-entry.js"
+    ],
+    "runtimeExtensions": [
+      "./dist/tools-entry.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.6.10",
+      "minGatewayVersion": "2026.6.10"
+    },
+    "build": {
+      "openclawVersion": "2026.6.33",
+      "pluginSdkVersion": "2026.6.33"
+    },
+    "configSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    }
+  }
+}

--- a/plugin/package.tools.json
+++ b/plugin/package.tools.json
@@ -1,0 +1,51 @@
+{
+  "name": "clawbits-openclaw-tools",
+  "version": "0.17.0",
+  "description": "OpenClaw tools and companion services for Clawbits.",
+  "type": "module",
+  "main": "dist/tools-entry.js",
+  "types": "dist/tools-entry.d.ts",
+  "files": [
+    "dist",
+    "skills",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.6.10"
+  },
+  "dependencies": {
+    "typebox": "^1.1.38"
+  },
+  "openclaw": {
+    "id": "clawbits-tools",
+    "name": "Clawbits Tools & Services",
+    "version": "0.17.0",
+    "entry": "./dist/tools-entry.js",
+    "extensions": [
+      "./dist/tools-entry.js"
+    ],
+    "runtimeExtensions": [
+      "./dist/tools-entry.js"
+    ],
+    "skills": [
+      "./skills"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.6.10",
+      "minGatewayVersion": "2026.6.10"
+    },
+    "build": {
+      "openclawVersion": "2026.6.33",
+      "pluginSdkVersion": "2026.6.33"
+    },
+    "configSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    }
+  }
+}

--- a/plugin/publish.sh
+++ b/plugin/publish.sh
@@ -107,6 +107,16 @@ cp "$PLUGIN_DIR/openclaw.plugin.json" \
    "$PLUGIN_DIR/package.json" \
    "$PUBLISH_DIR/"
 
+# Keep this pruning in lockstep with the "Stage publish directory" step in
+# .github/workflows/publish-clawhub-plugin.yaml. The tools entry belongs to the
+# clawbits-openclaw-tools package (it imports `typebox`, undeclared here) and
+# test-stubs/ are typecheck-only fakes for `openclaw/plugin-sdk/*`; the channel
+# manifest loads only ./src/index.ts + ./dist/index.js, so neither is reachable.
+rm -rf "$PUBLISH_DIR/src/test-stubs" "$PUBLISH_DIR/dist/test-stubs"
+rm -f "$PUBLISH_DIR/src/tools-entry.ts" \
+      "$PUBLISH_DIR/dist/tools-entry.js" \
+      "$PUBLISH_DIR/dist/tools-entry.d.ts"
+
 # Stamp the resolved version into the staged manifest + package.json (the
 # working-tree copies are intentionally left as placeholders). This mirrors
 # the "Stamp auto version" step in the CI publish workflow.

--- a/plugin/publish.sh
+++ b/plugin/publish.sh
@@ -99,13 +99,7 @@ cd "$REPO_ROOT"
 # 4. Stage a clean publish directory
 # ---------------------------------------------------------------------------
 step "Staging publish directory at $PUBLISH_DIR"
-rm -rf "$PUBLISH_DIR"
-mkdir -p "$PUBLISH_DIR"
-cp -r "$PLUGIN_DIR/dist" "$PLUGIN_DIR/src" "$PLUGIN_DIR/docs" "$PLUGIN_DIR/skills" "$PUBLISH_DIR/"
-cp "$PLUGIN_DIR/openclaw.plugin.json" \
-   "$PLUGIN_DIR/clawbits.config.example.json" \
-   "$PLUGIN_DIR/package.json" \
-   "$PUBLISH_DIR/"
+node "$PLUGIN_DIR/stage-channel.mjs" "$PUBLISH_DIR"
 
 # Stamp the resolved version into the staged manifest + package.json (the
 # working-tree copies are intentionally left as placeholders). This mirrors

--- a/plugin/src/accounts.ts
+++ b/plugin/src/accounts.ts
@@ -72,7 +72,7 @@ export function resolveDefaultClawBitsAccountId(cfg: OpenClawConfig): string {
  *  2. `channels.clawbits.accounts.<accountId>.*` (explicit override).
  *
  * Keys that do not belong on a per-account slice (`accounts`,
- * `defaultAccount`) are dropped from the merge base.
+ * `defaultAccount`, `serviceOwner`) are dropped from the merge base.
  */
 function mergeAccountConfig(
   section: ClawBitsChannelSection | undefined,
@@ -81,7 +81,7 @@ function mergeAccountConfig(
   const base: ClawBitsAccountConfig = {};
   if (section) {
     for (const [k, v] of Object.entries(section)) {
-      if (k === "accounts" || k === "defaultAccount") continue;
+      if (k === "accounts" || k === "defaultAccount" || k === "serviceOwner") continue;
       (base as Record<string, unknown>)[k] = v;
     }
   }

--- a/plugin/src/agent-body.ts
+++ b/plugin/src/agent-body.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { InboundContextPost, InboundFile } from "./inbound-poller.js";
+import type { InboundContextPost, InboundFile } from "./inbound-types.js";
 
 /**
  * Per-message preamble prepended to inbound text before it reaches the

--- a/plugin/src/attachments.ts
+++ b/plugin/src/attachments.ts
@@ -2,7 +2,7 @@ import type { ChannelGatewayContext } from "openclaw/plugin-sdk/core";
 import { formatBytes, type SavedInboundMedia } from "./agent-body.js";
 import { ClawBitsClient } from "./client.js";
 import { logWarn } from "./file-logger.js";
-import type { InboundFile, InboundMessage } from "./inbound-poller.js";
+import type { InboundAttachmentMessage, InboundFile } from "./inbound-types.js";
 import type { ResolvedClawBitsAccount } from "./types.js";
 
 /** Shared cap for media we decode + persist from a channel (chat + email).
@@ -117,7 +117,7 @@ async function fetchAttachmentForFile(
 
 export async function saveInboundAttachmentsForAgent(
   ctx: ChannelGatewayContext<ResolvedClawBitsAccount>,
-  msg: InboundMessage,
+  msg: InboundAttachmentMessage,
   client: ClawBitsClient | undefined,
 ): Promise<{ mediaContext: AgentMediaContext; savedByFileId: Map<string, SavedInboundMedia> }> {
   const files = msg.files ?? [];

--- a/plugin/src/automations/reconcile.ts
+++ b/plugin/src/automations/reconcile.ts
@@ -14,7 +14,7 @@ import { CHANNEL_ID } from "../accounts.js";
 import type { ClawBitsClient } from "../client.js";
 import { timedRequest } from "../client.js";
 import { type BasicLogger, logInfo } from "../file-logger.js";
-import { CLAWBITS_CHANNEL_ID_RE } from "../messaging-adapter.js";
+import { CLAWBITS_CHANNEL_ID_RE } from "../channel-target.js";
 import { PLUGIN_VERSION } from "../version.js";
 import {
   type CronDelivery,

--- a/plugin/src/challenge.ts
+++ b/plugin/src/challenge.ts
@@ -7,9 +7,14 @@ const DEFAULT_MAX_ATTEMPTS = 16;
 const DEFAULT_DELAY_MS = 150;
 
 export async function getChallenge(
-  client: ClawBitsClient
+  client: ClawBitsClient,
+  signal?: AbortSignal,
 ): Promise<Challenge> {
-  return client.request<Challenge>("GET", "/api/agentic/auth/challenge");
+  return client.request<Challenge>(
+    "GET",
+    "/api/agentic/auth/challenge",
+    signal ? { signal } : undefined,
+  );
 }
 
 export function answerChallenge(
@@ -31,7 +36,7 @@ export async function withChallenge<T>(
   client: ClawBitsClient,
   knownAnswers: Record<string, string>,
   fn: (answer: ChallengeAnswer) => Promise<T>,
-  opts: { maxAttempts?: number; delayMs?: number } = {}
+  opts: { maxAttempts?: number; delayMs?: number; signal?: AbortSignal } = {},
 ): Promise<T> {
   // Server samples challenges from a pool; retry until we land on one in
   // the known-answers dictionary.
@@ -39,13 +44,27 @@ export async function withChallenge<T>(
   const delay = opts.delayMs ?? DEFAULT_DELAY_MS;
   let lastUnknown: string | undefined;
   for (let i = 0; i < max; i++) {
-    const challenge = await getChallenge(client);
+    opts.signal?.throwIfAborted();
+    const challenge = await getChallenge(client, opts.signal);
     const ans = knownAnswers[challenge.challenge];
     if (ans !== undefined) {
       return fn({ sessionToken: challenge.session_token, response: ans });
     }
     lastUnknown = challenge.challenge;
-    if (i < max - 1) await new Promise((r) => setTimeout(r, delay));
+    if (i < max - 1) {
+      opts.signal?.throwIfAborted();
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(opts.signal?.reason);
+        };
+        const timer = setTimeout(() => {
+          opts.signal?.removeEventListener("abort", onAbort);
+          resolve();
+        }, delay);
+        opts.signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    }
   }
   throw new ClawBitsError({
     statusCode: 0,

--- a/plugin/src/channel-actions.ts
+++ b/plugin/src/channel-actions.ts
@@ -3,9 +3,8 @@
  *
  * Wires the plugin into OpenClaw's shared `message` tool surface so an
  * agent can invoke `react` (and read aggregated `reactions`) on posts in
- * a ClawBits channel, and save its profile description with
- * `update_description`. The text-send path is handled by `outboundAdapter.
- * sendText`; this adapter is purely for the non-send actions.
+ * a ClawBits channel. The text-send path is handled by `outboundAdapter.
+ * sendText`; this adapter is purely for channel-message actions.
  *
  * The contract this file targets:
  *   - `ChannelMessageActionAdapter` ({@link openclaw/plugin-sdk/channel-contract})
@@ -17,8 +16,8 @@
  *     ClawBits HTTP API via `mmTools.toggleReaction` and friends.
  *
  * Mirror of {@link openclaw/extensions/slack/src/channel-actions.ts}; kept
- * deliberately narrow — only `react` / `reactions` / `update_description`
- * are wired today. `send` remains on `outboundAdapter.sendText`.
+ * deliberately narrow — only `react` / `reactions` are wired today.
+ * `send` remains on `outboundAdapter.sendText`.
  */
 import type {
   AgentToolResult,
@@ -34,11 +33,6 @@ import { resolveClawBitsAccount } from "./accounts.js";
 import { resolveKnownAnswers, withChallenge } from "./challenge.js";
 import { ClawBitsClient } from "./client.js";
 import { ClawBitsError } from "./errors.js";
-import { frameEmailForDm } from "./email-dm-frame.js";
-import { logWarn } from "./file-logger.js";
-import * as agentTools from "./tools/agents.js";
-import * as emailTools from "./tools/email.js";
-import type { EmailSendAttachment } from "./tools/email.js";
 import * as mmTools from "./tools/mattermost.js";
 import type { ResolvedClawBitsAccount } from "./types.js";
 
@@ -98,7 +92,7 @@ function jsonOk<T extends Record<string, unknown>>(payload: T): AgentToolResult<
 
 /** Action subset this adapter handles end-to-end. `send` is intentionally
  *  not listed — it stays on `outboundAdapter.sendText`. */
-const CLAWBITS_ACTIONS = ["react", "reactions", "update_description", "send_email"] as const satisfies readonly ChannelMessageActionName[];
+const CLAWBITS_ACTIONS = ["react", "reactions"] as const satisfies readonly ChannelMessageActionName[];
 
 /** Schema fragment for the post-id field used by the reaction actions.
  *  Surfaced through `describeMessageTool` so the model knows the param
@@ -131,64 +125,12 @@ function buildReactionSchemaFragment(): ChannelMessageToolSchemaContribution {
   };
 }
 
-function buildDescriptionSchemaFragment(): ChannelMessageToolSchemaContribution {
-  return {
-    properties: {
-      description: {
-        type: "string",
-        description:
-          'One short, high-level profile description to save for action="update_description". Max 280 chars; prefer ~120 chars. Do not include private or sensitive specifics.',
-      },
-    },
-    actions: ["update_description"],
-  };
-}
-
-function buildSendEmailSchemaFragment(): ChannelMessageToolSchemaContribution {
-  return {
-    properties: {
-      subject: {
-        type: "string",
-        description: 'Subject line for action="send_email". Required.',
-      },
-      message: {
-        type: "string",
-        description:
-          'Plain-text body for action="send_email". Required. The email is always sent to your owner (the operator) — there is no recipient field.',
-      },
-      headers: {
-        type: "object",
-        additionalProperties: { type: "string" },
-        description: 'Optional extra email headers for action="send_email" (e.g. {"X-Priority":"1"}).',
-      },
-      attachments: {
-        type: "array",
-        description:
-          'Optional attachments for action="send_email". Each item is {"filename": string, "content_b64": base64-encoded bytes}.',
-        items: {
-          type: "object",
-          properties: {
-            filename: { type: "string" },
-            content_b64: { type: "string" },
-          },
-          required: ["filename", "content_b64"],
-        },
-      },
-    },
-    actions: ["send_email"],
-  };
-}
-
 export function describeClawBitsMessageTool(
   _params: ChannelMessageActionDiscoveryContext,
 ): ChannelMessageToolDiscovery {
   return {
     actions: CLAWBITS_ACTIONS,
-    schema: [
-      buildReactionSchemaFragment(),
-      buildDescriptionSchemaFragment(),
-      buildSendEmailSchemaFragment(),
-    ],
+    schema: [buildReactionSchemaFragment()],
   };
 }
 
@@ -206,20 +148,6 @@ function readMessageId(params: Record<string, unknown>): string {
     });
   }
   return id;
-}
-
-function readDescription(params: Record<string, unknown>): { description: string; truncated: boolean } {
-  const raw = readStringParam(params, "description");
-  if (!raw) {
-    throw new ClawBitsError({
-      statusCode: 0,
-      detail: 'description is required for action="update_description".',
-      path: "/",
-    });
-  }
-  const trimmed = raw.trim();
-  const description = trimmed.length > 280 ? trimmed.slice(0, 280).trimEnd() : trimmed;
-  return { description, truncated: description.length !== trimmed.length };
 }
 
 async function handleReact(ctx: ChannelMessageActionContext): Promise<AgentToolResult> {
@@ -290,152 +218,6 @@ async function handleReact(ctx: ChannelMessageActionContext): Promise<AgentToolR
   });
 }
 
-async function handleUpdateDescription(ctx: ChannelMessageActionContext): Promise<AgentToolResult> {
-  const account = resolveClawBitsAccount({
-    cfg: ctx.cfg,
-    accountId: ctx.accountId ?? undefined,
-  });
-  if (!account.enabled) {
-    throw new ClawBitsError({
-      statusCode: 0,
-      detail: "ClawBits account is disabled in config.",
-      path: "/",
-    });
-  }
-  if (!account.agentId) {
-    throw new ClawBitsError({
-      statusCode: 0,
-      detail: "Updating the Clawbits profile description requires agentId on the account.",
-      path: "/",
-    });
-  }
-  const { description, truncated } = readDescription(ctx.params);
-  const client = buildClient(account);
-  const updated = await agentTools.updateAgentDescription(client, account.agentId, description);
-  return jsonOk({
-    action: "update_description",
-    agentId: account.agentId,
-    description: updated.description ?? description,
-    description_generated_at: updated.description_generated_at ?? null,
-    description_source: updated.description_source ?? null,
-    truncated,
-  });
-}
-
-function readSendEmailParams(params: Record<string, unknown>): {
-  subject: string;
-  message: string;
-  headers?: Record<string, string>;
-  attachments?: EmailSendAttachment[];
-} {
-  const subject = readStringParam(params, "subject");
-  const message = readStringParam(params, "message") ?? readStringParam(params, "body");
-  if (!subject) {
-    throw new ClawBitsError({
-      statusCode: 0,
-      detail: 'subject is required for action="send_email".',
-      path: "/",
-    });
-  }
-  if (!message) {
-    throw new ClawBitsError({
-      statusCode: 0,
-      detail: 'message is required for action="send_email".',
-      path: "/",
-    });
-  }
-
-  let headers: Record<string, string> | undefined;
-  const rawHeaders = params["headers"];
-  if (rawHeaders && typeof rawHeaders === "object" && !Array.isArray(rawHeaders)) {
-    const collected: Record<string, string> = {};
-    for (const [k, v] of Object.entries(rawHeaders as Record<string, unknown>)) {
-      if (typeof v === "string") collected[k] = v;
-    }
-    if (Object.keys(collected).length > 0) headers = collected;
-  }
-
-  let attachments: EmailSendAttachment[] | undefined;
-  const rawAtts = params["attachments"];
-  if (Array.isArray(rawAtts)) {
-    const collected: EmailSendAttachment[] = [];
-    for (const entry of rawAtts) {
-      if (!entry || typeof entry !== "object") continue;
-      const e = entry as Record<string, unknown>;
-      const filename = typeof e["filename"] === "string" ? e["filename"] : undefined;
-      const contentB64 = typeof e["content_b64"] === "string" ? e["content_b64"] : undefined;
-      if (filename && contentB64) collected.push({ filename, content_b64: contentB64 });
-    }
-    if (collected.length > 0) attachments = collected;
-  }
-
-  return {
-    subject,
-    message,
-    ...(headers ? { headers } : {}),
-    ...(attachments ? { attachments } : {}),
-  };
-}
-
-async function handleSendEmail(ctx: ChannelMessageActionContext): Promise<AgentToolResult> {
-  const account = resolveClawBitsAccount({
-    cfg: ctx.cfg,
-    accountId: ctx.accountId ?? undefined,
-  });
-  if (!account.enabled) {
-    throw new ClawBitsError({
-      statusCode: 0,
-      detail: "ClawBits account is disabled in config.",
-      path: "/",
-    });
-  }
-  if (!account.agentId) {
-    throw new ClawBitsError({
-      statusCode: 0,
-      detail: "Sending email requires agentId on the account.",
-      path: "/",
-    });
-  }
-  const body = readSendEmailParams(ctx.params);
-  const client = buildClient(account);
-  const answers = resolveKnownAnswers(account.knownAnswers);
-  const sent = await withChallenge(client, answers, (ans) =>
-    emailTools.emailSend(client, account.agentId as string, body, ans),
-  );
-
-  // TEMPORARY: mirror the sent email into the operator DM channel so the owner
-  // sees agent-initiated mail in chat too — email otherwise never touches the
-  // DM surface. Best-effort: a failed mirror must not fail the send that already
-  // succeeded. Posts are authored by the agent, so the chat inbound poller's
-  // self-echo filter (inbound-poller.ts: `post.user_id === account.agentId`)
-  // drops them — no re-ingestion loop.
-  if (account.channelId) {
-    try {
-      await withChallenge(client, answers, (ans) =>
-        mmTools.postToChannel(
-          client,
-          account.channelId as string,
-          { message: frameEmailForDm({ kind: "sent", subject: body.subject, body: body.message }) },
-          ans,
-        ),
-      );
-    } catch (err) {
-      logWarn(
-        undefined,
-        `[clawbits/${ctx.accountId ?? "default"}] send_email->DM mirror failed: ${String((err as Error)?.message ?? err)}`,
-      );
-    }
-  }
-
-  return jsonOk({
-    action: "send_email",
-    status: sent.status ?? "sent",
-    to_addr: sent.to_addr ?? null,
-    from_addr: sent.from_addr ?? null,
-    subject: sent.subject ?? body.subject,
-  });
-}
-
 async function handleReactions(ctx: ChannelMessageActionContext): Promise<AgentToolResult> {
   const messageId = readMessageId(ctx.params);
   const account = resolveClawBitsAccount({
@@ -498,10 +280,6 @@ export function createClawBitsActions(): ChannelMessageActionAdapter {
           return await handleReact(ctx);
         case "reactions":
           return await handleReactions(ctx);
-        case "update_description":
-          return await handleUpdateDescription(ctx);
-        case "send_email":
-          return await handleSendEmail(ctx);
         default:
           throw new ClawBitsError({
             statusCode: 0,

--- a/plugin/src/channel-target.ts
+++ b/plugin/src/channel-target.ts
@@ -1,0 +1,3 @@
+/** Mattermost channel ids are RFC-4122 v4 UUIDs (8-4-4-4-12 hex). */
+export const CLAWBITS_CHANNEL_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/plugin/src/channel-watermarks.ts
+++ b/plugin/src/channel-watermarks.ts
@@ -52,6 +52,8 @@ export interface WatermarkStore {
 }
 
 const DEFAULT_STATE_FILENAME = "clawbits-channel-state.json";
+const EMAIL_STATE_FILENAME = "clawbits-email-state.json";
+const EMAIL_WATERMARK_KEY = "email:inbox";
 const FLUSH_DEBOUNCE_MS = 1000;
 const KEY_SEP = "\u0000";
 
@@ -62,10 +64,10 @@ function legacyStatePath(): string {
 }
 
 /** Durable default path — see the header note for the preference order. */
-function defaultStatePath(): string {
+function defaultStatePathFor(filename: string): string {
   const envDir = process.env["CLAWBITS_STATE_DIR"];
   if (envDir && envDir.trim().length > 0) {
-    return resolve(envDir.trim(), DEFAULT_STATE_FILENAME);
+    return resolve(envDir.trim(), filename);
   }
   try {
     const configDir = join(homedir(), ".config", "openclaw");
@@ -73,12 +75,16 @@ function defaultStatePath(): string {
     // signals "this install has a persistent config home" — reef's named
     // volume, or a self-hosted XDG setup. flush() creates the subdir.
     if (existsSync(configDir)) {
-      return join(configDir, "clawbits", DEFAULT_STATE_FILENAME);
+      return join(configDir, "clawbits", filename);
     }
   } catch {
     // homedir()/fs probing failed — fall through to the legacy location.
   }
-  return legacyStatePath();
+  return resolve(process.cwd(), filename);
+}
+
+function defaultStatePath(): string {
+  return defaultStatePathFor(DEFAULT_STATE_FILENAME);
 }
 
 /**
@@ -89,14 +95,21 @@ function defaultStatePath(): string {
 export class ChannelWatermarkStore implements WatermarkStore {
   private readonly map = new Map<string, number>();
   private readonly filePath: string | null;
-  private loaded = false;
+  private loadPromise: Promise<void> | undefined;
   private dirty = false;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private flushChain: Promise<void> = Promise.resolve();
+  private readonly migrationPath: string | undefined;
+  private readonly migrationChannelId: string | undefined;
   loadedExisting = false;
 
-  constructor(filePath?: string | null) {
+  constructor(
+    filePath?: string | null,
+    opts: { migrationPath?: string; migrationChannelId?: string } = {},
+  ) {
     this.filePath = filePath ?? null;
+    this.migrationPath = opts.migrationPath;
+    this.migrationChannelId = opts.migrationChannelId;
   }
 
   /** Resolved backing path, or null for a pure in-memory store. Logged at
@@ -112,6 +125,19 @@ export class ChannelWatermarkStore implements WatermarkStore {
     return new ChannelWatermarkStore(filePath ?? defaultStatePath());
   }
 
+  /** Separate companion-owned email state. On first load, migrate the email
+   *  UID from the legacy combined channel file, then write only this file so
+   *  independently installed channel/tools packages never race one snapshot. */
+  static emailFileBacked(filePath?: string): ChannelWatermarkStore {
+    return new ChannelWatermarkStore(
+      filePath ?? defaultStatePathFor(EMAIL_STATE_FILENAME),
+      {
+        migrationPath: defaultStatePath(),
+        migrationChannelId: EMAIL_WATERMARK_KEY,
+      },
+    );
+  }
+
   /** Pure in-memory store (no disk I/O). */
   static inMemory(): ChannelWatermarkStore {
     return new ChannelWatermarkStore(null);
@@ -121,44 +147,55 @@ export class ChannelWatermarkStore implements WatermarkStore {
     return `${accountId}${KEY_SEP}${channelId}`;
   }
 
-  private ingestSnapshot(raw: string): boolean {
+  private ingestSnapshot(raw: string, onlyChannelId?: string): boolean {
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return false;
+    let ingested = false;
     for (const [accountId, channels] of Object.entries(parsed as Record<string, unknown>)) {
       if (!channels || typeof channels !== "object") continue;
       for (const [channelId, value] of Object.entries(channels as Record<string, unknown>)) {
+        if (onlyChannelId && channelId !== onlyChannelId) continue;
         if (typeof value === "number" && Number.isFinite(value)) {
           this.map.set(this.keyFor(accountId, channelId), value);
+          ingested = true;
         }
       }
     }
-    return true;
+    return ingested;
   }
 
-  async load(): Promise<void> {
-    if (this.loaded) return;
-    this.loaded = true;
+  load(): Promise<void> {
+    this.loadPromise ??= this.loadOnce();
+    return this.loadPromise;
+  }
+
+  private async loadOnce(): Promise<void> {
     if (!this.filePath) return;
     try {
       this.loadedExisting = this.ingestSnapshot(await readFile(this.filePath, "utf8"));
       return;
     } catch {
-      // Missing or corrupt durable file — try the legacy location below.
+      // Missing or corrupt durable file — try migration locations below.
     }
-    // One-time migration read: a pre-0.16 install kept the file in the
-    // gateway's cwd. Ingest it (the next flush writes the durable path;
-    // the old file is left behind, harmless). Skipped when the configured
-    // path IS the legacy path.
-    const legacy = legacyStatePath();
-    if (legacy === this.filePath) return;
-    try {
-      this.loadedExisting = this.ingestSnapshot(await readFile(legacy, "utf8"));
-      if (this.loadedExisting) this.dirty = true;
-    } catch {
-      // Neither file → a genuine first boot (or both corrupt). Start empty:
-      // the next backlog runs untrimmed (at worst a one-time re-read), which
-      // is strictly safer than crashing the poller.
+    const migrationPaths = [this.migrationPath, legacyStatePath()].filter(
+      (path): path is string => Boolean(path && path !== this.filePath),
+    );
+    for (const migrationPath of [...new Set(migrationPaths)]) {
+      try {
+        this.loadedExisting = this.ingestSnapshot(
+          await readFile(migrationPath, "utf8"),
+          this.migrationChannelId,
+        );
+        if (this.loadedExisting) {
+          this.dirty = true;
+          return;
+        }
+      } catch {
+        // Keep trying migration sources.
+      }
     }
+    // No source → a genuine first boot (or all corrupt). Start empty: the
+    // next catch-up is bounded and safer than crashing the poller.
   }
 
   get(accountId: string, channelId: string): number | undefined {

--- a/plugin/src/companion-services.ts
+++ b/plugin/src/companion-services.ts
@@ -1,0 +1,208 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { listClawBitsAccountIds, resolveClawBitsAccount } from "./accounts.js";
+import { setCronHandle, type CronHandle } from "./automations/cron-handle.js";
+import { runAutomationsReconciler, wakeAutomationsReconciler } from "./automations/reconcile.js";
+import { ChannelWatermarkStore } from "./channel-watermarks.js";
+import { resolveKnownAnswers } from "./challenge.js";
+import { buildClientForAccount } from "./client-factory.js";
+import { dispatchInboundEmail } from "./email-adapter.js";
+import { runEmailPoller } from "./email-poller.js";
+import { logInfo, logWarn } from "./file-logger.js";
+import {
+  readSlimChannelHandoff,
+  resolveClawBitsServiceOwner,
+  supportsCompanionServices,
+} from "./service-handoff.js";
+import { getWorkspaceDir, setWorkspaceDir } from "./skills/scan.js";
+import {
+  claimSkillsReporter,
+  releaseSkillsReporter,
+  runSkillsReporter,
+} from "./skills/sync.js";
+import { registerUsageHooks } from "./usage/collector.js";
+import { runUsageReporter } from "./usage/reporter.js";
+
+interface GatewayHookContext {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  getCron?: () => CronHandle | undefined;
+}
+
+export interface CompanionServiceActivation {
+  active: boolean;
+  reason: "active" | "channel-owner" | "invalid-owner" | "missing-slim-channel";
+}
+
+export function resolveCompanionServiceActivation(
+  cfg: OpenClawConfig,
+  runtime: unknown,
+): CompanionServiceActivation {
+  const owner = resolveClawBitsServiceOwner(cfg);
+  if (!owner.valid) return { active: false, reason: "invalid-owner" };
+  if (owner.owner !== "tools") return { active: false, reason: "channel-owner" };
+  if (!supportsCompanionServices(readSlimChannelHandoff(runtime as never))) {
+    return { active: false, reason: "missing-slim-channel" };
+  }
+  return { active: true, reason: "active" };
+}
+
+interface RunningServices {
+  controller: AbortController;
+  tasks: Promise<void>[];
+  emailWatermarks: ChannelWatermarkStore;
+  usageActive: boolean;
+  skillsOwner?: string;
+}
+
+let running: RunningServices | undefined;
+
+async function stopRunningServices(): Promise<void> {
+  const current = running;
+  running = undefined;
+  if (!current) return;
+  current.controller.abort(new Error("Clawbits companion services stopped"));
+  await Promise.allSettled(current.tasks);
+  if (current.skillsOwner) releaseSkillsReporter(current.skillsOwner);
+  await current.emailWatermarks.flush();
+  setCronHandle(undefined);
+}
+
+function startTask(tasks: Promise<void>[], task: Promise<void>): void {
+  tasks.push(task.catch(() => undefined));
+}
+
+async function startCompanionServices(
+  api: OpenClawPluginApi,
+  cfg: OpenClawConfig,
+  ctx: GatewayHookContext,
+): Promise<void> {
+  await stopRunningServices();
+  const activation = resolveCompanionServiceActivation(cfg, api.runtime);
+  if (!activation.active) {
+    const message =
+      activation.reason === "invalid-owner"
+        ? "invalid channels.clawbits.serviceOwner; expected 'channel' or 'tools'"
+        : activation.reason === "missing-slim-channel"
+          ? "serviceOwner=tools but no compatible slim Clawbits channel is active; companion services remain idle"
+          : "serviceOwner is channel; companion services remain idle";
+    if (activation.reason === "channel-owner") logInfo(api.logger, `[clawbits-tools] ${message}`);
+    else logWarn(api.logger, `[clawbits-tools] ${message}`);
+    return;
+  }
+
+  setCronHandle(ctx.getCron?.());
+  setWorkspaceDir(ctx.workspaceDir);
+  const controller = new AbortController();
+  const tasks: Promise<void>[] = [];
+  const emailWatermarks = ChannelWatermarkStore.emailFileBacked();
+  const state: RunningServices = {
+    controller,
+    tasks,
+    emailWatermarks,
+    usageActive: false,
+  };
+  running = state;
+
+  for (const accountId of listClawBitsAccountIds(cfg)) {
+    const account = resolveClawBitsAccount({ cfg, accountId });
+    if (!account.enabled || !account.configured || !account.apiKey || !account.agentId) {
+      logInfo(
+        api.logger,
+        `[clawbits-tools/${accountId}] services idle: account disabled or not configured`,
+      );
+      continue;
+    }
+    const client = buildClientForAccount(account);
+    const answers = resolveKnownAnswers(account.knownAnswers);
+    state.usageActive = true;
+
+    startTask(
+      tasks,
+      runAutomationsReconciler({
+        client,
+        abortSignal: controller.signal,
+        accountId,
+        ownerChannelId: account.channelId,
+        log: api.logger,
+      }),
+    );
+    startTask(
+      tasks,
+      runUsageReporter({
+        client,
+        abortSignal: controller.signal,
+        accountId,
+        log: api.logger,
+      }),
+    );
+
+    if (!state.skillsOwner && claimSkillsReporter(accountId)) {
+      state.skillsOwner = accountId;
+      startTask(
+        tasks,
+        runSkillsReporter({
+          client,
+          abortSignal: controller.signal,
+          accountId,
+          workspaceDir: getWorkspaceDir(),
+          runtimeVersion: api.runtime.version,
+          log: api.logger,
+        }),
+      );
+    }
+
+    if (account.emailEnabled) {
+      startTask(
+        tasks,
+        runEmailPoller({
+          client,
+          account,
+          abortSignal: controller.signal,
+          log: api.logger,
+          watermarkStore: emailWatermarks,
+          onEmailMessage: (message) =>
+            dispatchInboundEmail(
+              {
+                cfg,
+                accountId,
+                account,
+                channelRuntime: api.runtime.channel,
+                log: api.logger,
+              },
+              message,
+              { client, answers },
+            ),
+        }),
+      );
+    }
+  }
+
+  logInfo(api.logger, "[clawbits-tools] companion services started");
+}
+
+export function registerCompanionServices(api: OpenClawPluginApi): void {
+  // Host hooks must be registered during plugin setup, but remain inert beside
+  // a legacy channel owner so no duplicate usage queue is accumulated.
+  registerUsageHooks({
+    on: (hook, handler) => {
+      api.on?.(hook, (event: unknown, ctx?: unknown) => {
+        if (running?.usageActive) handler(event, ctx);
+      });
+    },
+  });
+  api.on?.("gateway_start", async (_event: unknown, hookContext?: GatewayHookContext) => {
+    const cfg = hookContext?.config ?? api.config;
+    await startCompanionServices(api, cfg, hookContext ?? {});
+  });
+  api.on?.("cron_changed", () => {
+    if (running) wakeAutomationsReconciler();
+  });
+  api.on?.("gateway_stop", async () => {
+    await stopRunningServices();
+  });
+}
+
+export async function stopCompanionServicesForTests(): Promise<void> {
+  await stopRunningServices();
+}

--- a/plugin/src/companion-tools.ts
+++ b/plugin/src/companion-tools.ts
@@ -1,0 +1,367 @@
+import { Type } from "typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import {
+  listClawBitsAccountIds,
+  resolveClawBitsAccount,
+  resolveDefaultClawBitsAccountId,
+} from "./accounts.js";
+import { resolveKnownAnswers, withChallenge } from "./challenge.js";
+import { buildClientForAccount } from "./client-factory.js";
+import type { ClawBitsClient } from "./client.js";
+import { frameEmailForDm } from "./email-dm-frame.js";
+import { logWarn } from "./file-logger.js";
+import { getAgentInfo, updateAgentDescription } from "./tools/agents.js";
+import {
+  emailGet,
+  emailInbox,
+  emailSend,
+  type EmailDetail,
+  type EmailSendAttachment,
+} from "./tools/email.js";
+import { listChannels, listMembers, postToChannel } from "./tools/mattermost.js";
+
+export const CLAWBITS_TOOL_NAMES = [
+  "clawbits_channels_list",
+  "clawbits_channel_members",
+  "clawbits_email_inbox",
+  "clawbits_email_get",
+  "clawbits_agent_info",
+  "clawbits_email_send",
+  "clawbits_agent_description_update",
+] as const;
+
+const TOOL_REQUEST_TIMEOUT_MS = 30_000;
+const EMAIL_GET_TIMEOUT_MS = 60_000;
+
+function toolRequestSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function clientForConfig(
+  cfg: OpenClawConfig,
+  accountId?: string,
+  opts?: { requireEmail?: boolean },
+): { client: ClawBitsClient; agentId: string; accountId: string } {
+  const requestedAccountId = accountId?.trim();
+  if (requestedAccountId) {
+    const knownIds = listClawBitsAccountIds(cfg);
+    if (!knownIds.includes(requestedAccountId)) {
+      throw new Error(
+        `Unknown Clawbits account '${requestedAccountId}'. Configured account ids: ${knownIds.join(", ")}.`,
+      );
+    }
+  }
+  const resolvedAccountId = requestedAccountId || resolveDefaultClawBitsAccountId(cfg);
+  const account = resolveClawBitsAccount({ cfg, accountId: resolvedAccountId });
+  if (!account.configured || !account.agentId) {
+    throw new Error(
+      `Clawbits account '${resolvedAccountId}' is not configured; install and configure the Clawbits channel plugin first.`,
+    );
+  }
+  if (!account.enabled) {
+    throw new Error(
+      `Clawbits account '${resolvedAccountId}' is disabled (enabled=false in channels.clawbits config).`,
+    );
+  }
+  if (opts?.requireEmail && !account.emailEnabled) {
+    throw new Error(
+      `Clawbits email integration is disabled for account '${resolvedAccountId}' (emailEnabled=false).`,
+    );
+  }
+  return {
+    client: buildClientForAccount(account),
+    agentId: account.agentId,
+    accountId: resolvedAccountId,
+  };
+}
+
+function redactEmailAttachments(detail: EmailDetail): Omit<EmailDetail, "attachments"> & {
+  attachments?: Array<{ filename: string; content_type?: string; size?: number }>;
+  attachments_note?: string;
+} {
+  const attachments = detail.attachments;
+  if (!attachments?.length) return detail;
+  return {
+    ...detail,
+    attachments: attachments.map((attachment) => ({
+      filename: attachment.filename,
+      ...(attachment.content_type !== undefined
+        ? { content_type: attachment.content_type }
+        : {}),
+      size:
+        typeof attachment.size === "number"
+          ? attachment.size
+          : Math.floor((attachment.content_b64.length * 3) / 4),
+    })),
+    attachments_note: "Attachment bodies are omitted from tool output; metadata only.",
+  };
+}
+
+function jsonResult(value: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  details: unknown;
+} {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+    details: value,
+  };
+}
+
+const accountIdParameter = Type.Optional(
+  Type.String({
+    description:
+      "Clawbits account id from channels.clawbits.accounts. Uses the configured default when omitted.",
+    minLength: 1,
+  }),
+);
+
+const attachmentParameter = Type.Object({
+  filename: Type.String({ minLength: 1 }),
+  content_b64: Type.String({ minLength: 1 }),
+});
+
+export function registerClawbitsTools(api: OpenClawPluginApi): void {
+  api.registerTool(
+    {
+      name: CLAWBITS_TOOL_NAMES[0],
+      label: "List Clawbits Channels",
+      description: "List the Clawbits channels available to this agent.",
+      parameters: Type.Object({ accountId: accountIdParameter }),
+      async execute(_toolCallId, { accountId }, signal) {
+        signal?.throwIfAborted();
+        const { client } = clientForConfig(api.config, accountId);
+        return jsonResult(
+          await listChannels(client, toolRequestSignal(signal, TOOL_REQUEST_TIMEOUT_MS)),
+        );
+      },
+    },
+    { optional: true },
+  );
+
+  api.registerTool(
+    {
+      name: CLAWBITS_TOOL_NAMES[1],
+      label: "List Clawbits Channel Members",
+      description: "List members of one Clawbits channel.",
+      parameters: Type.Object({
+        channelId: Type.String({ description: "Clawbits channel id.", minLength: 1 }),
+        accountId: accountIdParameter,
+      }),
+      async execute(_toolCallId, { channelId, accountId }, signal) {
+        signal?.throwIfAborted();
+        const { client } = clientForConfig(api.config, accountId);
+        return jsonResult(
+          await listMembers(
+            client,
+            channelId,
+            toolRequestSignal(signal, TOOL_REQUEST_TIMEOUT_MS),
+          ),
+        );
+      },
+    },
+    { optional: true },
+  );
+
+  api.registerTool(
+    {
+      name: CLAWBITS_TOOL_NAMES[2],
+      label: "List Clawbits Email",
+      description: "List messages in this agent's Clawbits email inbox.",
+      parameters: Type.Object({
+        limit: Type.Optional(
+          Type.Integer({
+            description: "Maximum messages to return. Defaults to 20.",
+            minimum: 1,
+            maximum: 100,
+          }),
+        ),
+        offset: Type.Optional(
+          Type.Integer({ description: "Inbox offset. Defaults to 0.", minimum: 0 }),
+        ),
+        accountId: accountIdParameter,
+      }),
+      async execute(_toolCallId, { limit, offset, accountId }, signal) {
+        signal?.throwIfAborted();
+        const { client, agentId } = clientForConfig(api.config, accountId, {
+          requireEmail: true,
+        });
+        return jsonResult(
+          await emailInbox(client, agentId, {
+            limit: limit ?? 20,
+            offset: offset ?? 0,
+            signal: toolRequestSignal(signal, TOOL_REQUEST_TIMEOUT_MS),
+          }),
+        );
+      },
+    },
+    { optional: true },
+  );
+
+  api.registerTool(
+    {
+      name: CLAWBITS_TOOL_NAMES[3],
+      label: "Read Clawbits Email",
+      description:
+        "Read one Clawbits email by UID. Reading it marks it read. Attachment bodies are omitted; only attachment metadata is returned.",
+      parameters: Type.Object({
+        messageUid: Type.Integer({ description: "Email message UID.", minimum: 1 }),
+        accountId: accountIdParameter,
+      }),
+      async execute(_toolCallId, { messageUid, accountId }, signal) {
+        signal?.throwIfAborted();
+        const { client, agentId } = clientForConfig(api.config, accountId, {
+          requireEmail: true,
+        });
+        const detail = await emailGet(
+          client,
+          agentId,
+          messageUid,
+          toolRequestSignal(signal, EMAIL_GET_TIMEOUT_MS),
+        );
+        return jsonResult(redactEmailAttachments(detail));
+      },
+    },
+    { optional: true },
+  );
+
+  api.registerTool(
+    {
+      name: CLAWBITS_TOOL_NAMES[4],
+      label: "Get Clawbits Agent Information",
+      description: "Get this agent's Clawbits profile and organization information.",
+      parameters: Type.Object({ accountId: accountIdParameter }),
+      async execute(_toolCallId, { accountId }, signal) {
+        signal?.throwIfAborted();
+        const { client, agentId } = clientForConfig(api.config, accountId);
+        return jsonResult(
+          await getAgentInfo(
+            client,
+            agentId,
+            toolRequestSignal(signal, TOOL_REQUEST_TIMEOUT_MS),
+          ),
+        );
+      },
+    },
+    { optional: true },
+  );
+
+  api.registerTool(
+    {
+      name: CLAWBITS_TOOL_NAMES[5],
+      label: "Send Clawbits Email",
+      description:
+        "Send an email from this agent to its Clawbits operator. This is a paid, challenge-gated action.",
+      parameters: Type.Object({
+        subject: Type.String({ minLength: 1 }),
+        message: Type.String({ minLength: 1 }),
+        headers: Type.Optional(Type.Record(Type.String(), Type.String())),
+        attachments: Type.Optional(Type.Array(attachmentParameter)),
+        accountId: accountIdParameter,
+      }),
+      async execute(
+        _toolCallId,
+        { subject, message, headers, attachments, accountId },
+        signal,
+      ) {
+        signal?.throwIfAborted();
+        const normalizedSubject = subject.trim();
+        const normalizedMessage = message.trim();
+        if (!normalizedSubject || !normalizedMessage) {
+          throw new Error("Clawbits email subject and message must not be blank.");
+        }
+        const { client, agentId, accountId: resolvedAccountId } = clientForConfig(
+          api.config,
+          accountId,
+          { requireEmail: true },
+        );
+        const account = resolveClawBitsAccount({
+          cfg: api.config,
+          accountId: resolvedAccountId,
+        });
+        const answers = resolveKnownAnswers(account.knownAnswers);
+        const requestSignal = toolRequestSignal(signal, TOOL_REQUEST_TIMEOUT_MS);
+        const sent = await withChallenge(
+          client,
+          answers,
+          (answer) =>
+            emailSend(
+              client,
+              agentId,
+              {
+                subject: normalizedSubject,
+                message: normalizedMessage,
+                ...(headers ? { headers } : {}),
+                ...(attachments
+                  ? { attachments: attachments as EmailSendAttachment[] }
+                  : {}),
+              },
+              answer,
+              requestSignal,
+            ),
+          { signal: requestSignal },
+        );
+        if (account.channelId) {
+          try {
+            await withChallenge(
+              client,
+              answers,
+              (answer) =>
+                postToChannel(
+                  client,
+                  account.channelId as string,
+                  {
+                    message: frameEmailForDm({
+                      kind: "sent",
+                      subject: normalizedSubject,
+                      body: normalizedMessage,
+                    }),
+                  },
+                  answer,
+                  requestSignal,
+                ),
+              { signal: requestSignal },
+            );
+          } catch (err) {
+            logWarn(
+              api.logger,
+              `[clawbits/${resolvedAccountId}] email-send DM mirror failed: ${String((err as Error)?.message ?? err)}`,
+            );
+          }
+        }
+        return jsonResult(sent);
+      },
+    },
+    { optional: true },
+  );
+
+  api.registerTool(
+    {
+      name: CLAWBITS_TOOL_NAMES[6],
+      label: "Update Clawbits Agent Description",
+      description: "Update this agent's public Clawbits profile description.",
+      parameters: Type.Object({
+        description: Type.String({ minLength: 1, maxLength: 280 }),
+        accountId: accountIdParameter,
+      }),
+      async execute(_toolCallId, { description, accountId }, signal) {
+        signal?.throwIfAborted();
+        const normalizedDescription = description.trim();
+        if (!normalizedDescription) {
+          throw new Error("Clawbits agent description must not be blank.");
+        }
+        const { client, agentId } = clientForConfig(api.config, accountId);
+        return jsonResult(
+          await updateAgentDescription(
+            client,
+            agentId,
+            normalizedDescription,
+            toolRequestSignal(signal, TOOL_REQUEST_TIMEOUT_MS),
+          ),
+        );
+      },
+    },
+    { optional: true },
+  );
+}

--- a/plugin/src/email-adapter.ts
+++ b/plugin/src/email-adapter.ts
@@ -9,11 +9,11 @@
 // Per the user's design, email lands in the owner's main DM session (a
 // `direct` peer collapses to the agent's DM/main session per session.dmScope),
 // so the agent sees email and chat in one conversation. The explicit
-// `send_email` action (channel-actions.ts) is the guaranteed email path; the
-// auto reply-as-email here is best-effort for replies that flow through the
+// `clawbits_email_send` companion tool is the explicit email path; the auto
+// reply-as-email here is best-effort for replies that flow through the
 // buffered-block dispatcher's `deliver` callback.
 
-import type { ChannelGatewayContext } from "openclaw/plugin-sdk/core";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { dispatchInboundDirectDmWithRuntime } from "openclaw/plugin-sdk/channel-inbound";
 import { CHANNEL_ID } from "./accounts.js";
 import { buildAgentBody, clawbitsSessionId, formatBytes, type SavedInboundMedia } from "./agent-body.js";
@@ -35,13 +35,21 @@ import type { ResolvedClawBitsAccount } from "./types.js";
 // readable while the value lives in one place (`attachments.ts`).
 const EMAIL_ATTACHMENT_MAX_BYTES = CLAWBITS_ATTACHMENT_MAX_BYTES;
 
+export interface EmailDispatchContext {
+  cfg: OpenClawConfig;
+  accountId: string;
+  account: ResolvedClawBitsAccount;
+  channelRuntime?: unknown;
+  log?: { info?: (message: string) => void; warn?: (message: string) => void };
+}
+
 export interface DispatchInboundEmailDeps {
   /** Authenticated Clawbits client used for the send-back deliver callback. */
   client?: ClawBitsClient;
   /** Known challenge answers to satisfy the paid /email/send POST. */
   answers?: Record<string, string>;
-  /** Status sink so email activity shows up in channels.status. */
-  setStatus?: ChannelGatewayContext<ResolvedClawBitsAccount>["setStatus"];
+  /** Optional status sink retained for host integrations. */
+  setStatus?: (status: Record<string, unknown>) => void;
 }
 
 interface AgentMediaContext {
@@ -70,7 +78,7 @@ function buildMediaContext(saved: readonly SavedInboundMedia[]): AgentMediaConte
 /** Decode each inline base64 attachment and persist it to the host media store
  *  via the same `runtime.media.saveMediaBuffer` seam `attachments.ts` uses. */
 async function saveEmailAttachments(
-  ctx: ChannelGatewayContext<ResolvedClawBitsAccount>,
+  ctx: EmailDispatchContext,
   email: EmailInboundMessage,
 ): Promise<{ mediaContext: AgentMediaContext; saved: SavedInboundMedia[]; lines: string[] }> {
   const atts = email.attachments ?? [];
@@ -232,10 +240,9 @@ function collapseWhitespace(s: string): string {
 export function buildEmailTurnText(email: EmailInboundMessage, attachmentLines: string[]): string {
   const header = [
     "[Email received]",
-    "You just received a new email in your Clawbits mailbox. To respond reliably,",
-    "use the message tool's `send_email` action (it always goes to your owner).",
-    "Simply replying to this message also emails your owner, but that path is",
-    "best-effort.",
+    "You just received a new email in your Clawbits mailbox. Replying to this",
+    "message emails your owner. For a separate outbound email, use the optional",
+    "`clawbits_email_send` tool.",
     `From: ${email.fromAddr || "(unknown)"}`,
     `To: ${email.toAddr || "(you)"}`,
     `Subject: ${email.subject || "(no subject)"}`,
@@ -258,7 +265,7 @@ export function buildEmailTurnText(email: EmailInboundMessage, attachmentLines: 
  * so a non-gateway load (tests) short-circuits cleanly.
  */
 export async function dispatchInboundEmail(
-  ctx: ChannelGatewayContext<ResolvedClawBitsAccount>,
+  ctx: EmailDispatchContext,
   email: EmailInboundMessage,
   deps: DispatchInboundEmailDeps = {},
 ): Promise<void> {

--- a/plugin/src/email-dm-frame.ts
+++ b/plugin/src/email-dm-frame.ts
@@ -8,7 +8,7 @@
 // markdown-it, so bold + blockquote (and its vertical bar) are honoured.
 //
 // TEMPORARY: this whole email->DM mirror is a stopgap; see callers in
-// `email-adapter.ts` and `channel-actions.ts`.
+// `email-adapter.ts` and `companion-tools.ts`.
 
 export type EmailDmKind = "received" | "reply_sent" | "sent";
 

--- a/plugin/src/gateway-adapter.ts
+++ b/plugin/src/gateway-adapter.ts
@@ -30,17 +30,11 @@ import {
   pluginDebug,
   writeTraceSpan,
 } from "./file-logger.js";
-import { dispatchInboundEmail } from "./email-adapter.js";
-import { runEmailPoller } from "./email-poller.js";
 import {
   runInboundPoller,
   type InboundMessage,
 } from "./inbound-poller.js";
 import { runLivenessPinger } from "./liveness.js";
-import { runAutomationsReconciler } from "./automations/reconcile.js";
-import { runUsageReporter } from "./usage/reporter.js";
-import { claimSkillsReporter, runSkillsReporter } from "./skills/sync.js";
-import { getWorkspaceDir } from "./skills/scan.js";
 import {
   resolveInboundDispatchGuardTarget,
   withInboundDispatchGuard,
@@ -936,69 +930,6 @@ export const gatewayAdapter: ChannelGatewayAdapter<ResolvedClawBitsAccount> = {
       log: ctx.log,
     });
 
-    // Automations reconciler: converges the local gateway cron to the operator's
-    // desired set in Clawbits and self-reports actual state. Fire-and-forget like
-    // the liveness pinger (shares the abort signal, never throws). It manages cron
-    // via the in-process getCron handle captured in the gateway_start hook, so it
-    // idles harmlessly until that handle is available.
-    void runAutomationsReconciler({
-      client,
-      abortSignal: ctx.abortSignal,
-      accountId: ctx.accountId,
-      ownerChannelId: account.channelId,
-      log: ctx.log,
-    });
-
-    // AI-usage reporter: drains the in-process usage collector (fed by the
-    // reply-dispatch / llm_output hooks registered in index.ts) and
-    // self-reports token usage. Fire-and-forget like the pinger; telemetry-
-    // class and billing-exempt server-side. On a multi-account gateway only
-    // the first account's loop drains the shared queue.
-    void runUsageReporter({
-      client,
-      abortSignal: ctx.abortSignal,
-      accountId: ctx.accountId,
-      log: ctx.log,
-    });
-
-    // Skills sync: converges the agent's skill directories to the desired set
-    // and reports what is actually there. Single owner per gateway, since the
-    // roots are shared across accounts.
-    if (claimSkillsReporter(ctx.accountId)) {
-      void runSkillsReporter({
-        client,
-        abortSignal: ctx.abortSignal,
-        accountId: ctx.accountId,
-        workspaceDir: getWorkspaceDir(),
-        log: ctx.log,
-      });
-    }
-
-    // Email ingestion runs alongside the chat poller. Fire-and-forget like the
-    // liveness pinger: it shares the poller's abort signal, self-disables if the
-    // server reports email is not configured (503), and never throws, so it
-    // can't disturb the inbound poller below. Gated on the per-account flag
-    // (default on; harmless on upgrade thanks to the 503 self-disable).
-    //
-    // Email and chat both dispatch into the owner's DM/main session. Concurrent
-    // turns into the same session are serialized by core's session write-lock
-    // (`acquireSessionWriteLock` in the embedded agent runner), so the two
-    // pollers can't corrupt shared session state by running at once.
-    if (account.emailEnabled) {
-      void runEmailPoller({
-        client,
-        account,
-        abortSignal: ctx.abortSignal,
-        log: ctx.log,
-        watermarkStore: channelWatermarkStore,
-        onEmailMessage: (msg) =>
-          dispatchInboundEmail(ctx, msg, {
-            client,
-            answers,
-            setStatus: ctx.setStatus,
-          }),
-      });
-    }
 
     // Inbound gating moved server-side: the agentic GET only returns
     // posts that have already been approved (or were authored by the

--- a/plugin/src/inbound-poller.ts
+++ b/plugin/src/inbound-poller.ts
@@ -12,7 +12,6 @@ import type { WatermarkStore } from "./channel-watermarks.js";
 import { resolveKnownAnswers, withChallenge } from "./challenge.js";
 import type { ClawBitsClient } from "./client.js";
 import { ClawBitsError } from "./errors.js";
-import { wakeAutomationsReconciler } from "./automations/reconcile.js";
 import {
   consoleErrorWithFile,
   logDebug,
@@ -1510,10 +1509,6 @@ export async function runInboundPoller(opts: InboundPollerOptions): Promise<void
         forceReconcilePoll = true;
         scheduleNextWebSocketControlRefresh();
         stopSse("agent WebSocket connected");
-        // An automation.sync nudge only rides this socket, so any desired-state
-        // change made while it was down was missed. Reconcile now instead of
-        // waiting for the reconciler's next poll.
-        wakeAutomationsReconciler(account.accountId);
         logInfo(log, `[clawbits/${account.accountId}] agent WebSocket connected`);
       },
       onEvent: (event) => {
@@ -1542,9 +1537,7 @@ export async function runInboundPoller(opts: InboundPollerOptions): Promise<void
           return;
         }
         if (event.type === "automation.sync") {
-          // Operator changed this agent's desired automations — wake the
-          // reconciler so it converges near-instantly instead of on the timer.
-          wakeAutomationsReconciler(account.accountId);
+          // Reconciled by the companion service on its bounded poll interval.
           return;
         }
         // `mutualist.consider` is the pre-rename name for the same event; kept

--- a/plugin/src/inbound-types.ts
+++ b/plugin/src/inbound-types.ts
@@ -1,0 +1,25 @@
+/** Shared inbound shapes used by channel chat and companion email dispatch. */
+export interface InboundFile {
+  fileId: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  downloadUrl: string | null;
+  thumbnailUrl: string | null;
+  width: number | null;
+  height: number | null;
+  durationMs: number | null;
+}
+
+export interface InboundContextPost {
+  postId: string;
+  senderId: string;
+  text: string;
+  createAt: number;
+  isSelf: boolean;
+}
+
+export interface InboundAttachmentMessage {
+  postId: string;
+  files?: InboundFile[];
+}

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -2,35 +2,14 @@ import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
 import { registerClawBitsCli } from "./cli.js";
 import { clawbitsChannelPlugin } from "./plugin.js";
 import { registerActivitySubscription } from "./activity/subscription.js";
-import { setCronHandle, type CronHandle } from "./automations/cron-handle.js";
-import { setWorkspaceDir } from "./skills/scan.js";
-import { wakeAutomationsReconciler } from "./automations/reconcile.js";
-import { registerUsageHooks } from "./usage/collector.js";
-
-/** The hook surface we use from the gateway runtime. The vendored SDK stub
- *  types these loosely, so cast to exactly what we call. `ctx.getCron()` returns
- *  the real in-process CronService (fuller than its public type) — see
- *  automations/cron-handle.ts. The cron hooks are infra (not
- *  conversation-content), so this global-origin plugin registers them with no
- *  extra grant; the usage hooks add `reply_payload_sending` (ungated) and
- *  `llm_output` (conversation-class — the gateway blocks it with a warn
- *  diagnostic unless the operator config grants
- *  `plugins.entries.clawbits.hooks.allowConversationAccess=true`). */
-interface GatewayHookApi {
-  on?: (
-    hook: string,
-    handler: (
-      event: unknown,
-      ctx?: { getCron?: () => CronHandle | undefined; workspaceDir?: string },
-    ) => void,
-  ) => void;
-}
+import { registerSlimChannelHandoff } from "./service-handoff.js";
+import { PLUGIN_VERSION } from "./version.js";
 
 export default defineChannelPluginEntry({
   id: "clawbits",
   name: "Clawbits Human Channel",
   description:
-    "Bridge an OpenClaw agent to its Clawbits organization. For agents: run `openclaw clawbits signup --endpoint <url> --org-id <id> --signup-token <token>` for a non-interactive signup. The token comes from the Clawbits Add agent prompt. The command mints tokens, resolves the owner channel, and prints exact config commands. To self-update when instructed to update the Clawbits plugin, run `openclaw clawbits update` — it prints the exact upgrade command for this install: for a remote install, `openclaw plugins install clawhub:clawbits-openclaw-plugin --pin --force` (fetches the newest compatible release and stays pinned); for a local checkout, a rebuild + force-reinstall recipe. Run the printed command; it auto-restarts the managed Gateway, so treat it as a terminal action and re-announce once the channel reconnects. To report which plugin version you are running (and whether it is current), run `openclaw clawbits version` (add `--check` to compare against the server's minimum). Use `--json` for automation/debug output. Config lives under channels.clawbits.accounts.*. Bundled Clawbits documentation ships with this package under `clawbits-openclaw-plugin/docs/`.",
+    "Bridge an OpenClaw agent to its Clawbits organization. For agents: run `openclaw clawbits signup --endpoint <url> --org-id <id> --signup-token <token>` for a non-interactive signup. The token comes from the Clawbits Add agent prompt. The command mints tokens, resolves the owner channel, and prints exact config commands. To self-update when instructed to update the Clawbits plugin, first follow `docs/SPLIT_MIGRATION.md` when moving from a version before 0.17; it installs the companion before the slim channel. Otherwise run `openclaw clawbits update` — it prints the exact upgrade command for this install: for a remote install, `openclaw plugins install clawhub:clawbits-openclaw-plugin --pin --force` (fetches the newest compatible release and stays pinned); for a local checkout, a rebuild + force-reinstall recipe. Run the printed command; it auto-restarts the managed Gateway, so treat it as a terminal action and re-announce once the channel reconnects. To report which plugin version you are running (and whether it is current), run `openclaw clawbits version` (add `--check` to compare against the server's minimum). Use `--json` for automation/debug output. Config lives under channels.clawbits.accounts.*. Bundled Clawbits documentation ships with this package under `clawbits-openclaw-plugin/docs/`.",
   plugin: clawbitsChannelPlugin,
   configSchema: {
     type: "object",
@@ -38,31 +17,15 @@ export default defineChannelPluginEntry({
     properties: {},
   },
   registerCliMetadata: registerClawBitsCli,
-  // gateway_start hands us the in-process cron handle (the reconciler's write
-  // path — no token/pairing/scope needed); cron_changed wakes the reconciler so
-  // the mirror reflects local changes (including jobs made via `openclaw cron`).
   registerFull: (api) => {
-    const hookApi = api as unknown as GatewayHookApi;
-    hookApi.on?.("gateway_start", (_event, ctx) => {
-      try {
-        setCronHandle(ctx?.getCron?.());
-      } catch {
-        /* best-effort: leave the reconciler idle if cron access is unavailable */
-      }
-      setWorkspaceDir(ctx?.workspaceDir);
-    });
-    hookApi.on?.("cron_changed", () => {
-      wakeAutomationsReconciler();
-    });
-    // AI-usage collector: passive observers on the reply-dispatch and (where
-    // granted) llm_output planes; the per-account usage reporter loop drains
-    // what these queue. See docs/protocol/AGENT_USAGE_TRACKING_PLAN.md.
-    registerUsageHooks(hookApi);
-    // Live activity: subscribe to the (ungated) agent-event plane —
-    // lifecycle/assistant/thinking/tool — feeding the streaming text lane
-    // and the ephemeral activity lane. Observer-only; degrades to the
-    // shimmer-then-final UX on hosts without the API. See
-    // docs/protocol/LIVE_AGENT_ACTIVITY_PLAN.md.
+    // Public runtime-context marker consumed by the companion plugin. An old
+    // channel has no marker, so a newly installed companion remains idle and
+    // cannot duplicate the old channel-owned background services.
+    const handoff = registerSlimChannelHandoff(api.runtime, PLUGIN_VERSION);
+    api.on?.("gateway_stop", () => handoff?.dispose());
+
+    // Live activity belongs to the channel: lifecycle/assistant/thinking/tool
+    // events feed the streaming reply and ephemeral channel status lanes.
     registerActivitySubscription(api);
   },
 });

--- a/plugin/src/messaging-adapter.ts
+++ b/plugin/src/messaging-adapter.ts
@@ -1,5 +1,8 @@
 import type { ChannelMessagingAdapter } from "openclaw/plugin-sdk/core";
 import { CHANNEL_ID, resolveClawBitsAccount } from "./accounts.js";
+import { CLAWBITS_CHANNEL_ID_RE } from "./channel-target.js";
+
+export { CLAWBITS_CHANNEL_ID_RE } from "./channel-target.js";
 
 // ---------------------------------------------------------------------------
 // messaging adapter - target validation + resolution for the shared message
@@ -7,10 +10,6 @@ import { CHANNEL_ID, resolveClawBitsAccount } from "./accounts.js";
 // channel UUIDs and the plugin's `default` route, so the agent's codex
 // `tools.message({action:"send"})` call never reaches outbound.sendText.
 // ---------------------------------------------------------------------------
-
-/** Mattermost channel ids are RFC-4122 v4 UUIDs (8-4-4-4-12 hex). */
-export const CLAWBITS_CHANNEL_ID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Treat as a routable Clawbits identifier: UUID-shaped channel id or the
  *  `default` sentinel that resolves to the configured channel for the

--- a/plugin/src/service-handoff.ts
+++ b/plugin/src/service-handoff.ts
@@ -1,0 +1,99 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+
+export const CLAWBITS_SERVICE_HANDOFF_CAPABILITY = "service-handoff";
+export const CLAWBITS_SLIM_CHANNEL_MIN_VERSION = "0.17.0";
+
+export type ClawBitsServiceOwner = "channel" | "tools";
+
+export interface ClawBitsServiceHandoff {
+  channelVersion: string;
+  servicesMovedTo: "clawbits-tools";
+}
+
+interface RuntimeContextRegistry {
+  register(params: {
+    channelId: string;
+    capability: string;
+    context: ClawBitsServiceHandoff;
+  }): { dispose(): void };
+  get<T>(params: {
+    channelId: string;
+    capability: string;
+  }): T | undefined;
+}
+
+interface RuntimeWithContexts {
+  channel?: { runtimeContexts?: RuntimeContextRegistry };
+}
+
+function compareVersions(a: string, b: string): number {
+  const leftParts = a.split(".");
+  const rightParts = b.split(".");
+  if (
+    leftParts.some((part) => !/^\d+$/u.test(part)) ||
+    rightParts.some((part) => !/^\d+$/u.test(part))
+  ) {
+    return Number.NaN;
+  }
+  const left = leftParts.map(Number);
+  const right = rightParts.map(Number);
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const l = left[i] ?? 0;
+    const r = right[i] ?? 0;
+    if (!Number.isFinite(l) || !Number.isFinite(r)) return Number.NaN;
+    if (l !== r) return l < r ? -1 : 1;
+  }
+  return 0;
+}
+
+export function resolveClawBitsServiceOwner(
+  cfg: OpenClawConfig,
+): { owner: ClawBitsServiceOwner; valid: boolean; configured: boolean } {
+  const channels = cfg.channels;
+  const section =
+    channels && typeof channels === "object"
+      ? (channels as Record<string, unknown>)["clawbits"]
+      : undefined;
+  const raw =
+    section && typeof section === "object"
+      ? (section as Record<string, unknown>)["serviceOwner"]
+      : undefined;
+  if (raw === undefined || raw === null || raw === "") {
+    return { owner: "channel", valid: true, configured: false };
+  }
+  if (raw === "channel" || raw === "tools") {
+    return { owner: raw, valid: true, configured: true };
+  }
+  return { owner: "channel", valid: false, configured: true };
+}
+
+export function registerSlimChannelHandoff(
+  runtime: RuntimeWithContexts | undefined,
+  channelVersion: string,
+): { dispose(): void } | undefined {
+  return runtime?.channel?.runtimeContexts?.register({
+    channelId: "clawbits",
+    capability: CLAWBITS_SERVICE_HANDOFF_CAPABILITY,
+    context: { channelVersion, servicesMovedTo: "clawbits-tools" },
+  });
+}
+
+export function readSlimChannelHandoff(
+  runtime: RuntimeWithContexts | undefined,
+): ClawBitsServiceHandoff | undefined {
+  return runtime?.channel?.runtimeContexts?.get<ClawBitsServiceHandoff>({
+    channelId: "clawbits",
+    capability: CLAWBITS_SERVICE_HANDOFF_CAPABILITY,
+  });
+}
+
+export function supportsCompanionServices(
+  handoff: ClawBitsServiceHandoff | undefined,
+): boolean {
+  if (!handoff || handoff.servicesMovedTo !== "clawbits-tools") return false;
+  const comparison = compareVersions(
+    handoff.channelVersion,
+    CLAWBITS_SLIM_CHANNEL_MIN_VERSION,
+  );
+  return Number.isFinite(comparison) && comparison >= 0;
+}

--- a/plugin/src/test-stubs/openclaw/plugin-sdk/core.ts
+++ b/plugin/src/test-stubs/openclaw/plugin-sdk/core.ts
@@ -1,10 +1,20 @@
-export function defineChannelPluginEntry<T extends { plugin?: unknown } & Record<string, unknown>>(entry: T) {
+export function defineChannelPluginEntry<
+  T extends {
+    plugin?: unknown;
+    registerCliMetadata?: (api: Record<string, unknown>) => void;
+    registerFull?: (api: Record<string, any>) => void;
+  } & Record<string, unknown>,
+>(entry: T) {
   return {
     ...entry,
     channelPlugin: entry.plugin,
-    register(api: { registrationMode?: string; registerChannel?: (opts: { plugin: unknown }) => void }) {
+    register(api: Record<string, any>) {
+      entry.registerCliMetadata?.(api);
       if (api.registrationMode === "cli-metadata") return;
       if (entry.plugin) api.registerChannel?.({ plugin: entry.plugin });
+      if (api.registrationMode === undefined || api.registrationMode === "full") {
+        entry.registerFull?.(api);
+      }
     },
   };
 }

--- a/plugin/src/test-stubs/openclaw/plugin-sdk/plugin-entry.ts
+++ b/plugin/src/test-stubs/openclaw/plugin-sdk/plugin-entry.ts
@@ -1,0 +1,59 @@
+import type { Static, TSchema } from "typebox";
+import type { OpenClawConfig } from "./core.js";
+
+export interface StubAgentToolResult {
+  content: Array<{ type: string; text: string }>;
+  details?: unknown;
+}
+
+export interface StubAgentTool<TParamsSchema extends TSchema = TSchema> {
+  name: string;
+  label: string;
+  description: string;
+  parameters: TParamsSchema;
+  execute: (
+    toolCallId: string,
+    params: Static<TParamsSchema>,
+    signal?: AbortSignal,
+    onUpdate?: (update: unknown) => void,
+  ) => unknown;
+}
+
+export interface OpenClawPluginApi {
+  registrationMode?: string;
+  config: OpenClawConfig;
+  pluginConfig?: Record<string, unknown>;
+  logger: { info?: (message: string) => void; warn?: (message: string) => void };
+  runtime: {
+    version: string;
+    channel?: {
+      runtimeContexts?: {
+        register(params: {
+          channelId: string;
+          capability: string;
+          context: unknown;
+        }): { dispose(): void };
+        get<T>(params: { channelId: string; capability: string }): T | undefined;
+      };
+      [key: string]: unknown;
+    };
+  };
+  registerTool<TParamsSchema extends TSchema>(
+    tool: StubAgentTool<TParamsSchema>,
+    opts?: { optional?: boolean; name?: string },
+  ): void;
+  on?: (hook: string, handler: (...args: any[]) => unknown) => void;
+  [key: string]: unknown;
+}
+
+interface PluginEntryDefinition {
+  id: string;
+  name: string;
+  description: string;
+  configSchema?: unknown;
+  register(api: OpenClawPluginApi): void;
+}
+
+export function definePluginEntry<T extends PluginEntryDefinition>(definition: T): T {
+  return definition;
+}

--- a/plugin/src/test-stubs/openclaw/plugin-sdk/tool-plugin.ts
+++ b/plugin/src/test-stubs/openclaw/plugin-sdk/tool-plugin.ts
@@ -1,0 +1,116 @@
+import type { Static, TSchema } from "typebox";
+import type { OpenClawConfig } from "./core.js";
+
+export interface ToolPluginApi {
+  config: OpenClawConfig;
+  registerTool?: (tool: DefinedToolPluginTool) => void;
+  [key: string]: unknown;
+}
+
+export interface ToolPluginExecutionContext {
+  api: ToolPluginApi;
+  signal?: AbortSignal;
+  toolCallId: string;
+  onUpdate?: (update: unknown) => void;
+}
+
+type ToolPluginConfig<TConfigSchema extends TSchema | undefined> =
+  TConfigSchema extends TSchema ? Static<TConfigSchema> : Record<string, never>;
+
+export interface DefinedToolPluginTool {
+  name: string;
+  label: string;
+  description: string;
+  parameters: TSchema;
+  optional: boolean;
+  execute?: (
+    params: unknown,
+    config: unknown,
+    context: ToolPluginExecutionContext,
+  ) => unknown;
+}
+
+interface ToolPluginToolDefinition<TConfig, TParamsSchema extends TSchema> {
+  name: string;
+  label?: string;
+  description: string;
+  parameters: TParamsSchema;
+  optional?: boolean;
+  execute: (
+    params: Static<TParamsSchema>,
+    config: TConfig,
+    context: ToolPluginExecutionContext,
+  ) => unknown;
+}
+
+interface DefineToolPluginOptions<TConfigSchema extends TSchema | undefined> {
+  id: string;
+  name: string;
+  description: string;
+  configSchema?: TConfigSchema;
+  tools: (
+    tool: <TParamsSchema extends TSchema>(
+      definition: ToolPluginToolDefinition<ToolPluginConfig<TConfigSchema>, TParamsSchema>,
+    ) => DefinedToolPluginTool,
+  ) => readonly DefinedToolPluginTool[];
+}
+
+export interface DefinedToolPluginEntry {
+  id: string;
+  name: string;
+  description: string;
+  configSchema: TSchema | undefined;
+  register(api: ToolPluginApi): void;
+}
+
+export interface ToolPluginMetadata {
+  id: string;
+  name: string;
+  description: string;
+  tools: Array<{
+    name: string;
+    label: string;
+    description: string;
+    parameters: TSchema;
+    optional: boolean;
+  }>;
+}
+
+const metadata = new WeakMap<object, ToolPluginMetadata>();
+
+export function defineToolPlugin<TConfigSchema extends TSchema | undefined = undefined>(
+  definition: DefineToolPluginOptions<TConfigSchema>,
+): DefinedToolPluginEntry {
+  const tools = definition.tools((toolDefinition) => ({
+    ...toolDefinition,
+    label: toolDefinition.label ?? toolDefinition.name,
+    optional: toolDefinition.optional ?? false,
+    execute: toolDefinition.execute as DefinedToolPluginTool["execute"],
+  }));
+  const entry = {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    configSchema: definition.configSchema,
+    register(api: ToolPluginApi): void {
+      for (const tool of tools) api.registerTool?.(tool);
+    },
+  };
+  metadata.set(entry, {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    tools: tools.map((tool) => ({
+      name: tool.name,
+      label: tool.label,
+      description: tool.description,
+      parameters: tool.parameters,
+      optional: tool.optional,
+    })),
+  });
+  return entry;
+}
+
+export function getToolPluginMetadata(entry: unknown): ToolPluginMetadata | undefined {
+  return entry !== null && typeof entry === "object" ? metadata.get(entry) : undefined;
+}

--- a/plugin/src/tools-entry.ts
+++ b/plugin/src/tools-entry.ts
@@ -1,0 +1,221 @@
+import { Type } from "typebox";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+import {
+  listClawBitsAccountIds,
+  resolveClawBitsAccount,
+  resolveDefaultClawBitsAccountId,
+} from "./accounts.js";
+import { buildClientForAccount } from "./client-factory.js";
+import type { ClawBitsClient } from "./client.js";
+import { getAgentInfo } from "./tools/agents.js";
+import { emailGet, emailInbox, type EmailDetail } from "./tools/email.js";
+import { listChannels, listMembers } from "./tools/mattermost.js";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+
+export const CLAWBITS_TOOL_NAMES = [
+  "clawbits_channels_list",
+  "clawbits_channel_members",
+  "clawbits_email_inbox",
+  "clawbits_email_get",
+  "clawbits_agent_info",
+] as const;
+
+// Every tool call is bounded so a stalled connection can't pin the tool
+// runtime on undici's ~300s header/body default (see RequestOptions.signal in
+// client.ts). email_get gets longer: the server inlines attachment payloads
+// in the response body.
+const TOOL_REQUEST_TIMEOUT_MS = 30_000;
+const EMAIL_GET_TIMEOUT_MS = 60_000;
+
+/** The runtime's abort signal (when provided) combined with a hard timeout. */
+function toolRequestSignal(
+  context: { signal?: AbortSignal },
+  timeoutMs: number,
+): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return context.signal ? AbortSignal.any([context.signal, timeout]) : timeout;
+}
+
+function clientForConfig(
+  cfg: OpenClawConfig,
+  accountId?: string,
+  opts?: { requireEmail?: boolean },
+): { client: ClawBitsClient; agentId: string } {
+  const requestedAccountId = accountId?.trim();
+  // An explicit account id must name a configured account. Without this check
+  // a typo would silently fall through to the top-level inline account (the
+  // merge in resolveClawBitsAccount treats accounts.<id> as an optional
+  // override) and read — or mark read — the wrong mailbox.
+  if (requestedAccountId) {
+    const knownIds = listClawBitsAccountIds(cfg);
+    if (!knownIds.includes(requestedAccountId)) {
+      throw new Error(
+        `Unknown Clawbits account '${requestedAccountId}'. Configured account ids: ${knownIds.join(", ")}.`,
+      );
+    }
+  }
+  const resolvedAccountId = requestedAccountId || resolveDefaultClawBitsAccountId(cfg);
+  const account = resolveClawBitsAccount({ cfg, accountId: resolvedAccountId });
+  if (!account.configured || !account.agentId) {
+    throw new Error(
+      `Clawbits account '${resolvedAccountId}' is not configured; install and configure the Clawbits channel plugin first.`,
+    );
+  }
+  // Honor the same operator kill switches the channel plugin honors; the
+  // tools ride the channel's credentials and must not outlive its gates.
+  if (!account.enabled) {
+    throw new Error(
+      `Clawbits account '${resolvedAccountId}' is disabled (enabled=false in channels.clawbits config).`,
+    );
+  }
+  if (opts?.requireEmail && !account.emailEnabled) {
+    throw new Error(
+      `Clawbits email integration is disabled for account '${resolvedAccountId}' (emailEnabled=false).`,
+    );
+  }
+  return {
+    client: buildClientForAccount(account),
+    agentId: account.agentId,
+  };
+}
+
+/**
+ * Replace inline base64 attachment bodies with metadata. The channel path
+ * never hands raw bytes to the model either (email-adapter caps and uploads
+ * them); a multi-megabyte content_b64 in a tool result would flood the
+ * agent's context.
+ */
+function redactEmailAttachments(detail: EmailDetail): Omit<EmailDetail, "attachments"> & {
+  attachments?: Array<{ filename: string; content_type?: string; size?: number }>;
+  attachments_note?: string;
+} {
+  const attachments = detail.attachments;
+  if (!attachments?.length) return detail;
+  return {
+    ...detail,
+    attachments: attachments.map((attachment) => ({
+      filename: attachment.filename,
+      ...(attachment.content_type !== undefined
+        ? { content_type: attachment.content_type }
+        : {}),
+      size:
+        typeof attachment.size === "number"
+          ? attachment.size
+          : Math.floor((attachment.content_b64.length * 3) / 4),
+    })),
+    attachments_note: "Attachment bodies are omitted from tool output; metadata only.",
+  };
+}
+
+const accountIdParameter = Type.Optional(
+  Type.String({
+    description:
+      "Clawbits account id from channels.clawbits.accounts. Uses the configured default when omitted.",
+    minLength: 1,
+  }),
+);
+
+export default defineToolPlugin({
+  id: "clawbits-tools",
+  name: "Clawbits Tools",
+  description: "Read Clawbits channels, email, and agent information.",
+  tools: (tool) => [
+    tool({
+      name: CLAWBITS_TOOL_NAMES[0],
+      label: "List Clawbits Channels",
+      description: "List the Clawbits channels available to this agent.",
+      parameters: Type.Object({ accountId: accountIdParameter }),
+      optional: true,
+      async execute({ accountId }, _config, context) {
+        context.signal?.throwIfAborted();
+        const { client } = clientForConfig(context.api.config, accountId);
+        return listChannels(client, toolRequestSignal(context, TOOL_REQUEST_TIMEOUT_MS));
+      },
+    }),
+    tool({
+      name: CLAWBITS_TOOL_NAMES[1],
+      label: "List Clawbits Channel Members",
+      description: "List members of one Clawbits channel.",
+      parameters: Type.Object({
+        channelId: Type.String({ description: "Clawbits channel id.", minLength: 1 }),
+        accountId: accountIdParameter,
+      }),
+      optional: true,
+      async execute({ channelId, accountId }, _config, context) {
+        context.signal?.throwIfAborted();
+        const { client } = clientForConfig(context.api.config, accountId);
+        return listMembers(
+          client,
+          channelId,
+          toolRequestSignal(context, TOOL_REQUEST_TIMEOUT_MS),
+        );
+      },
+    }),
+    tool({
+      name: CLAWBITS_TOOL_NAMES[2],
+      label: "List Clawbits Email",
+      description: "List messages in this agent's Clawbits email inbox.",
+      parameters: Type.Object({
+        limit: Type.Optional(
+          Type.Integer({ description: "Maximum messages to return. Defaults to 20.", minimum: 1, maximum: 100 }),
+        ),
+        offset: Type.Optional(
+          Type.Integer({ description: "Inbox offset. Defaults to 0.", minimum: 0 }),
+        ),
+        accountId: accountIdParameter,
+      }),
+      optional: true,
+      async execute({ limit, offset, accountId }, _config, context) {
+        context.signal?.throwIfAborted();
+        const { client, agentId } = clientForConfig(context.api.config, accountId, {
+          requireEmail: true,
+        });
+        return emailInbox(client, agentId, {
+          limit: limit ?? 20,
+          offset: offset ?? 0,
+          signal: toolRequestSignal(context, TOOL_REQUEST_TIMEOUT_MS),
+        });
+      },
+    }),
+    tool({
+      name: CLAWBITS_TOOL_NAMES[3],
+      label: "Read Clawbits Email",
+      description:
+        "Read one Clawbits email by UID. Reading it marks it read. Attachment bodies are omitted; only attachment metadata is returned.",
+      parameters: Type.Object({
+        messageUid: Type.Integer({ description: "Email message UID.", minimum: 1 }),
+        accountId: accountIdParameter,
+      }),
+      optional: true,
+      async execute({ messageUid, accountId }, _config, context) {
+        context.signal?.throwIfAborted();
+        const { client, agentId } = clientForConfig(context.api.config, accountId, {
+          requireEmail: true,
+        });
+        const detail = await emailGet(
+          client,
+          agentId,
+          messageUid,
+          toolRequestSignal(context, EMAIL_GET_TIMEOUT_MS),
+        );
+        return redactEmailAttachments(detail);
+      },
+    }),
+    tool({
+      name: CLAWBITS_TOOL_NAMES[4],
+      label: "Get Clawbits Agent Information",
+      description: "Get this agent's Clawbits profile and organization information.",
+      parameters: Type.Object({ accountId: accountIdParameter }),
+      optional: true,
+      async execute({ accountId }, _config, context) {
+        context.signal?.throwIfAborted();
+        const { client, agentId } = clientForConfig(context.api.config, accountId);
+        return getAgentInfo(
+          client,
+          agentId,
+          toolRequestSignal(context, TOOL_REQUEST_TIMEOUT_MS),
+        );
+      },
+    }),
+  ],
+});

--- a/plugin/src/tools-entry.ts
+++ b/plugin/src/tools-entry.ts
@@ -1,0 +1,22 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerCompanionServices } from "./companion-services.js";
+import { registerClawbitsTools } from "./companion-tools.js";
+
+export { CLAWBITS_TOOL_NAMES } from "./companion-tools.js";
+
+export default definePluginEntry({
+  id: "clawbits-tools",
+  name: "Clawbits Tools & Services",
+  description: "Clawbits tools and companion background services.",
+  configSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+  register(api) {
+    registerClawbitsTools(api);
+    if (api.registrationMode === "full" || api.registrationMode === undefined) {
+      registerCompanionServices(api);
+    }
+  },
+});

--- a/plugin/src/tools/agents.ts
+++ b/plugin/src/tools/agents.ts
@@ -43,22 +43,25 @@ export async function getSignupRequest(
 
 export async function getAgentInfo(
   client: ClawBitsClient,
-  agentId: string
+  agentId: string,
+  signal?: AbortSignal
 ): Promise<unknown> {
   return client.request<unknown>(
     "GET",
-    `/api/agentic/agents/${client.encodePath(agentId)}/info`
+    `/api/agentic/agents/${client.encodePath(agentId)}/info`,
+    { signal }
   );
 }
 
 export async function updateAgentDescription(
   client: ClawBitsClient,
   agentId: string,
-  description: string
+  description: string,
+  signal?: AbortSignal,
 ): Promise<AgentDescriptionUpdated> {
   return client.request<AgentDescriptionUpdated>(
     "PUT",
     `/api/agentic/agents/${client.encodePath(agentId)}/description`,
-    { json: { description } }
+    { json: { description }, ...(signal ? { signal } : {}) }
   );
 }

--- a/plugin/src/tools/agents.ts
+++ b/plugin/src/tools/agents.ts
@@ -43,11 +43,13 @@ export async function getSignupRequest(
 
 export async function getAgentInfo(
   client: ClawBitsClient,
-  agentId: string
+  agentId: string,
+  signal?: AbortSignal
 ): Promise<unknown> {
   return client.request<unknown>(
     "GET",
-    `/api/agentic/agents/${client.encodePath(agentId)}/info`
+    `/api/agentic/agents/${client.encodePath(agentId)}/info`,
+    { signal }
   );
 }
 

--- a/plugin/src/tools/email.ts
+++ b/plugin/src/tools/email.ts
@@ -99,7 +99,7 @@ export async function emailCount(
 export async function emailInbox(
   client: ClawBitsClient,
   agentId: string,
-  opts: { limit?: number; offset?: number } = {},
+  opts: { limit?: number; offset?: number; signal?: AbortSignal } = {},
 ): Promise<EmailListResponse> {
   const params = new URLSearchParams();
   if (typeof opts.limit === "number" && Number.isFinite(opts.limit) && opts.limit > 0) {
@@ -112,6 +112,7 @@ export async function emailInbox(
   return client.request<EmailListResponse>(
     "GET",
     `${emailBase(client, agentId)}/inbox${query ? `?${query}` : ""}`,
+    { signal: opts.signal },
   );
 }
 
@@ -120,10 +121,12 @@ export async function emailGet(
   client: ClawBitsClient,
   agentId: string,
   messageUid: number | string,
+  signal?: AbortSignal,
 ): Promise<EmailDetail> {
   return client.request<EmailDetail>(
     "GET",
     `${emailBase(client, agentId)}/${client.encodePath(String(messageUid))}`,
+    { signal },
   );
 }
 
@@ -133,10 +136,11 @@ export async function emailSend(
   agentId: string,
   body: EmailSendRequest,
   answer: ChallengeAnswer,
+  signal?: AbortSignal,
 ): Promise<EmailSendResponse> {
   return client.request<EmailSendResponse>(
     "POST",
     `${emailBase(client, agentId)}/send`,
-    { json: body, challenge: answer },
+    { json: body, challenge: answer, ...(signal ? { signal } : {}) },
   );
 }

--- a/plugin/src/tools/email.ts
+++ b/plugin/src/tools/email.ts
@@ -99,7 +99,7 @@ export async function emailCount(
 export async function emailInbox(
   client: ClawBitsClient,
   agentId: string,
-  opts: { limit?: number; offset?: number } = {},
+  opts: { limit?: number; offset?: number; signal?: AbortSignal } = {},
 ): Promise<EmailListResponse> {
   const params = new URLSearchParams();
   if (typeof opts.limit === "number" && Number.isFinite(opts.limit) && opts.limit > 0) {
@@ -112,6 +112,7 @@ export async function emailInbox(
   return client.request<EmailListResponse>(
     "GET",
     `${emailBase(client, agentId)}/inbox${query ? `?${query}` : ""}`,
+    { signal: opts.signal },
   );
 }
 
@@ -120,10 +121,12 @@ export async function emailGet(
   client: ClawBitsClient,
   agentId: string,
   messageUid: number | string,
+  signal?: AbortSignal,
 ): Promise<EmailDetail> {
   return client.request<EmailDetail>(
     "GET",
     `${emailBase(client, agentId)}/${client.encodePath(String(messageUid))}`,
+    { signal },
   );
 }
 

--- a/plugin/src/tools/mattermost.ts
+++ b/plugin/src/tools/mattermost.ts
@@ -33,9 +33,10 @@ export async function createChannel(
 }
 
 export async function listChannels(
-  client: ClawBitsClient
+  client: ClawBitsClient,
+  signal?: AbortSignal
 ): Promise<unknown> {
-  return client.request<unknown>("GET", "/api/agentic/mm/channels");
+  return client.request<unknown>("GET", "/api/agentic/mm/channels", { signal });
 }
 
 export async function addMember(
@@ -66,11 +67,13 @@ export async function removeMember(
 
 export async function listMembers(
   client: ClawBitsClient,
-  channelId: string
+  channelId: string,
+  signal?: AbortSignal
 ): Promise<unknown> {
   return client.request<unknown>(
     "GET",
-    `/api/agentic/mm/channels/${client.encodePath(channelId)}/members`
+    `/api/agentic/mm/channels/${client.encodePath(channelId)}/members`,
+    { signal }
   );
 }
 

--- a/plugin/src/tools/mattermost.ts
+++ b/plugin/src/tools/mattermost.ts
@@ -33,9 +33,10 @@ export async function createChannel(
 }
 
 export async function listChannels(
-  client: ClawBitsClient
+  client: ClawBitsClient,
+  signal?: AbortSignal
 ): Promise<unknown> {
-  return client.request<unknown>("GET", "/api/agentic/mm/channels");
+  return client.request<unknown>("GET", "/api/agentic/mm/channels", { signal });
 }
 
 export async function addMember(
@@ -66,11 +67,13 @@ export async function removeMember(
 
 export async function listMembers(
   client: ClawBitsClient,
-  channelId: string
+  channelId: string,
+  signal?: AbortSignal
 ): Promise<unknown> {
   return client.request<unknown>(
     "GET",
-    `/api/agentic/mm/channels/${client.encodePath(channelId)}/members`
+    `/api/agentic/mm/channels/${client.encodePath(channelId)}/members`,
+    { signal }
   );
 }
 
@@ -78,12 +81,13 @@ export async function postToChannel(
   client: ClawBitsClient,
   channelId: string,
   body: ChannelPost,
-  answer: ChallengeAnswer
+  answer: ChallengeAnswer,
+  signal?: AbortSignal,
 ): Promise<unknown> {
   return client.request<unknown>(
     "POST",
     `/api/agentic/mm/channels/${client.encodePath(channelId)}/posts`,
-    { json: body, challenge: answer }
+    { json: body, challenge: answer, ...(signal ? { signal } : {}) }
   );
 }
 

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -147,6 +147,8 @@ export interface ClawBitsAccountConfig {
 export interface ClawBitsChannelSection extends ClawBitsAccountConfig {
   accounts?: Record<string, Partial<ClawBitsAccountConfig>>;
   defaultAccount?: string;
+  /** Migration owner for non-channel background services. Missing defaults to the legacy channel owner. */
+  serviceOwner?: "channel" | "tools";
 }
 
 export interface ResolvedClawBitsAccount {

--- a/plugin/src/typestubs/openclaw-plugin-sdk.d.ts
+++ b/plugin/src/typestubs/openclaw-plugin-sdk.d.ts
@@ -430,6 +430,7 @@ declare module "openclaw/plugin-sdk/core" {
     registrationMode?: "full" | "setup-only" | "setup-runtime" | "cli-metadata" | "discovery";
     registerTool?: (opts: unknown) => void;
     registerHook?: (event: string, handler: unknown) => void;
+    on?: (event: string, handler: (...args: unknown[]) => unknown) => void;
     registerChannel?: (opts: { plugin: ChannelPlugin<unknown> }) => void;
     registerCli?: (
       registrar: (ctx: OpenClawPluginCliContext) => void | Promise<void>,
@@ -438,7 +439,20 @@ declare module "openclaw/plugin-sdk/core" {
         descriptors?: OpenClawPluginCliCommandDescriptor[];
       },
     ) => void;
-    runtime?: unknown;
+    runtime?: {
+      version?: string;
+      channel?: {
+        runtimeContexts?: {
+          register(params: {
+            channelId: string;
+            capability: string;
+            context: unknown;
+          }): { dispose(): void };
+          get<T>(params: { channelId: string; capability: string }): T | undefined;
+        };
+        [key: string]: unknown;
+      };
+    };
     [key: string]: unknown;
   }
 

--- a/plugin/stage-artifact.mjs
+++ b/plugin/stage-artifact.mjs
@@ -1,0 +1,175 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = dirname(fileURLToPath(import.meta.url));
+const distRoot = resolve(pluginRoot, "dist");
+
+function scannableSource(path) {
+  return readFileSync(path, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//gu, "")
+    .replace(/^\s*\/\/.*$/gmu, "");
+}
+
+const importPattern = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)['"](\.[^'"]+)['"]/gu;
+const bareImportPattern =
+  /^\s*(?:import\s+[^'"\n]*?\bfrom\s*|export\s+[^'"\n]*?\bfrom\s*|import\s*\(?\s*)['"]([^'".][^'"]*)['"]/gmu;
+const opaqueDynamicImportPattern = /\bimport\s*\(\s*(?!['"])[^)\s]/gu;
+
+function packageRoot(specifier) {
+  const segments = specifier.split("/");
+  return specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+}
+
+export function stageArtifact(options) {
+  const {
+    targetArg,
+    entry,
+    packageFile,
+    manifestFile,
+    readmeFile,
+    extraDirectories = [],
+    extraFiles = [],
+    label,
+  } = options;
+  if (!targetArg) throw new Error(`usage: node stage-${label}.mjs <target-dir>`);
+
+  const entryPath = resolve(distRoot, entry);
+  if (!existsSync(entryPath)) {
+    throw new Error(`dist/${entry} is missing; run the plugin build first`);
+  }
+  const targetRoot = isAbsolute(targetArg) ? targetArg : resolve(process.cwd(), targetArg);
+  const targetDist = resolve(targetRoot, "dist");
+
+  const protectedRoots = [pluginRoot, process.cwd()];
+  for (const root of protectedRoots) {
+    if (targetRoot === root || root.startsWith(`${targetRoot}${sep}`)) {
+      throw new Error(`refusing to stage into ${targetRoot}: it contains ${root}`);
+    }
+  }
+  if (existsSync(targetRoot)) {
+    if (!statSync(targetRoot).isDirectory()) {
+      throw new Error(`refusing to replace non-directory target: ${targetRoot}`);
+    }
+    const entries = readdirSync(targetRoot);
+    if (entries.length > 0 && !entries.includes("openclaw.plugin.json")) {
+      throw new Error(
+        `refusing to delete ${targetRoot}: existing directory does not look like a previous staging output`,
+      );
+    }
+  }
+
+  const packageJson = JSON.parse(readFileSync(resolve(pluginRoot, packageFile), "utf8"));
+  const declaredExternalPackages = new Set([
+    "openclaw", // host-provided plugin SDK
+    ...Object.keys(packageJson.dependencies ?? {}),
+    ...Object.keys(packageJson.peerDependencies ?? {}),
+  ]);
+
+  function checkBareSpecifier(importer, specifier) {
+    if (specifier.startsWith("node:")) return;
+    const root = packageRoot(specifier);
+    if (!declaredExternalPackages.has(root)) {
+      throw new Error(
+        `undeclared external import in ${relative(distRoot, importer)}: '${specifier}' ` +
+          `(add '${root}' to ${packageFile} dependencies/peerDependencies or remove the import)`,
+      );
+    }
+  }
+
+  function insideDist(path) {
+    const rel = relative(distRoot, path);
+    return rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+  }
+
+  function resolveLocalImport(importer, specifier) {
+    const candidate = resolve(dirname(importer), specifier);
+    if (!insideDist(candidate)) {
+      throw new Error(`local import escapes dist: ${relative(distRoot, importer)} -> ${specifier}`);
+    }
+    if (!existsSync(candidate)) {
+      throw new Error(`missing local import: ${relative(distRoot, importer)} -> ${specifier}`);
+    }
+    return candidate;
+  }
+
+  const visited = new Set();
+  function visit(path) {
+    if (visited.has(path)) return;
+    visited.add(path);
+    const source = scannableSource(path);
+    const opaque = source.match(opaqueDynamicImportPattern);
+    if (opaque) {
+      throw new Error(
+        `unresolvable dynamic import in ${relative(distRoot, path)}: '${opaque[0]}…'`,
+      );
+    }
+    for (const match of source.matchAll(bareImportPattern)) {
+      checkBareSpecifier(path, match[1]);
+    }
+    for (const match of source.matchAll(importPattern)) {
+      visit(resolveLocalImport(path, match[1]));
+    }
+  }
+
+  const visitedDeclarations = new Set();
+  function visitDeclaration(path) {
+    if (visitedDeclarations.has(path)) return;
+    visitedDeclarations.add(path);
+    const source = scannableSource(path);
+    for (const match of source.matchAll(bareImportPattern)) {
+      checkBareSpecifier(path, match[1]);
+    }
+    for (const match of source.matchAll(importPattern)) {
+      const specifier = match[1];
+      const candidate = resolve(dirname(path), specifier).replace(/\.js$/u, ".d.ts");
+      if (!insideDist(candidate)) {
+        throw new Error(
+          `declaration import escapes dist: ${relative(distRoot, path)} -> ${specifier}`,
+        );
+      }
+      if (!existsSync(candidate)) {
+        throw new Error(
+          `missing declaration for import: ${relative(distRoot, path)} -> ${specifier}`,
+        );
+      }
+      visitDeclaration(candidate);
+    }
+  }
+
+  visit(entryPath);
+  for (const source of [...visited]) {
+    const declaration = source.replace(/\.js$/u, ".d.ts");
+    if (existsSync(declaration)) visitDeclaration(declaration);
+  }
+
+  rmSync(targetRoot, { recursive: true, force: true });
+  mkdirSync(targetDist, { recursive: true });
+  const staged = [...new Set([...visited, ...visitedDeclarations])].sort();
+  for (const source of staged) {
+    const destination = resolve(targetDist, relative(distRoot, source));
+    mkdirSync(dirname(destination), { recursive: true });
+    cpSync(source, destination);
+  }
+
+  cpSync(resolve(pluginRoot, packageFile), resolve(targetRoot, "package.json"));
+  cpSync(resolve(pluginRoot, manifestFile), resolve(targetRoot, "openclaw.plugin.json"));
+  if (readmeFile) cpSync(resolve(pluginRoot, readmeFile), resolve(targetRoot, "README.md"));
+  for (const file of extraFiles) {
+    cpSync(resolve(pluginRoot, file), resolve(targetRoot, file));
+  }
+  for (const directory of extraDirectories) {
+    cpSync(resolve(pluginRoot, directory), resolve(targetRoot, directory), { recursive: true });
+  }
+  console.log(
+    `staged ${label}: ${visited.size} runtime modules (+${visitedDeclarations.size} declarations) in ${targetRoot}`,
+  );
+}

--- a/plugin/stage-channel.mjs
+++ b/plugin/stage-channel.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { stageArtifact } from "./stage-artifact.mjs";
+
+try {
+  stageArtifact({
+    targetArg: process.argv[2],
+    entry: "index.js",
+    packageFile: "package.json",
+    manifestFile: "openclaw.plugin.json",
+    readmeFile: "README.md",
+    extraDirectories: ["docs"],
+    extraFiles: ["clawbits.config.example.json"],
+    label: "channel",
+  });
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/plugin/stage-tools.mjs
+++ b/plugin/stage-tools.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = dirname(fileURLToPath(import.meta.url));
+const distRoot = resolve(pluginRoot, "dist");
+const targetArg = process.argv[2];
+if (!targetArg) {
+  console.error("usage: node stage-tools.mjs <target-dir>");
+  process.exit(2);
+}
+if (!existsSync(resolve(distRoot, "tools-entry.js"))) {
+  console.error("dist/tools-entry.js is missing; run the plugin build first");
+  process.exit(1);
+}
+
+const targetRoot = isAbsolute(targetArg) ? targetArg : resolve(process.cwd(), targetArg);
+const targetDist = resolve(targetRoot, "dist");
+
+// The target is wiped before staging, so refuse anything that isn't clearly a
+// staging output: the plugin tree itself, the current directory, an ancestor
+// of either, or an existing non-empty directory without a prior stage's
+// openclaw.plugin.json marker.
+function guardTarget() {
+  const protectedRoots = [pluginRoot, process.cwd()];
+  for (const root of protectedRoots) {
+    if (targetRoot === root || root.startsWith(`${targetRoot}${sep}`)) {
+      throw new Error(`refusing to stage into ${targetRoot}: it contains ${root}`);
+    }
+  }
+  if (!existsSync(targetRoot)) return;
+  if (!statSync(targetRoot).isDirectory()) {
+    throw new Error(`refusing to replace non-directory target: ${targetRoot}`);
+  }
+  const entries = readdirSync(targetRoot);
+  if (entries.length > 0 && !entries.includes("openclaw.plugin.json")) {
+    throw new Error(
+      `refusing to delete ${targetRoot}: existing directory does not look like a previous staging output`,
+    );
+  }
+}
+
+// Import scanning is text-based over tsc output (comments survive: tsc runs
+// without removeComments). Lines that are only comment prose are dropped
+// before scanning so a phrase like `// moved out of "./types.js"` can't be
+// mistaken for an import; trailing comments on code lines still fail loud in
+// resolveLocalImport rather than silently mis-staging.
+function scannableSource(path) {
+  return readFileSync(path, "utf8").replace(/^\s*(?:\/\/|\/?\*).*$/gmu, "");
+}
+
+// Matches relative static imports/re-exports, side-effect imports, and
+// dynamic imports — including whitespace or a newline after `import(`, which
+// tsc emits verbatim from source. Captures only `.`-prefixed specifiers, so
+// prose like `from 'disk'` inside a code string can't join the graph.
+const importPattern = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)['"](\.[^'"]+)['"]/gu;
+// Bare specifiers, scanned from line-anchored import/export statements only
+// (tsc emits them at line starts); a mid-line bare dynamic import would slip
+// past this check but still resolves via the peer at runtime.
+const bareImportPattern =
+  /^\s*(?:import\s+[^'"\n]*?\bfrom\s*|export\s+[^'"\n]*?\bfrom\s*|import\s*\(?\s*)['"]([^'".][^'"]*)['"]/gmu;
+// Any dynamic import NOT followed by a string literal can't be resolved
+// statically and would otherwise be dropped from the artifact silently.
+const opaqueDynamicImportPattern = /\bimport\s*\(\s*(?!['"])[^)\s]/gu;
+
+// Bare specifiers the staged artifact may legitimately leave external. Every
+// non-node bare import must be declared in package.tools.json so the
+// published package can't accumulate undeclared runtime dependencies.
+const toolsPackage = JSON.parse(
+  readFileSync(resolve(pluginRoot, "package.tools.json"), "utf8"),
+);
+const declaredExternalPackages = new Set([
+  ...Object.keys(toolsPackage.dependencies ?? {}),
+  ...Object.keys(toolsPackage.peerDependencies ?? {}),
+]);
+
+function packageRoot(specifier) {
+  const segments = specifier.split("/");
+  return specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+}
+
+function checkBareSpecifier(importer, specifier) {
+  if (specifier.startsWith("node:")) return;
+  const root = packageRoot(specifier);
+  if (!declaredExternalPackages.has(root)) {
+    throw new Error(
+      `undeclared external import in ${relative(distRoot, importer)}: '${specifier}' ` +
+        `(add '${root}' to package.tools.json dependencies/peerDependencies or remove the import)`,
+    );
+  }
+}
+
+function insideDist(path) {
+  const rel = relative(distRoot, path);
+  return rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+function resolveLocalImport(importer, specifier) {
+  const candidate = resolve(dirname(importer), specifier);
+  if (!insideDist(candidate)) {
+    throw new Error(`local import escapes dist: ${relative(distRoot, importer)} -> ${specifier}`);
+  }
+  if (!existsSync(candidate)) {
+    throw new Error(`missing local import: ${relative(distRoot, importer)} -> ${specifier}`);
+  }
+  return candidate;
+}
+
+const visited = new Set();
+
+function visit(path) {
+  if (visited.has(path)) return;
+  visited.add(path);
+  const source = scannableSource(path);
+  const opaque = source.match(opaqueDynamicImportPattern);
+  if (opaque) {
+    throw new Error(
+      `unresolvable dynamic import in ${relative(distRoot, path)}: '${opaque[0]}…' — ` +
+        `the staged artifact would silently miss its target`,
+    );
+  }
+  for (const match of source.matchAll(bareImportPattern)) {
+    checkBareSpecifier(path, match[1]);
+  }
+  for (const match of source.matchAll(importPattern)) {
+    visit(resolveLocalImport(path, match[1]));
+  }
+}
+
+// Declaration files import type-only modules (e.g. ./types.js) that the
+// runtime graph never touches because tsc erases those imports from the .js
+// output. Walk the .d.ts graph separately so the published `types` entry
+// resolves; d.ts-only modules stage just their declaration.
+const visitedDeclarations = new Set();
+
+function visitDeclaration(path) {
+  if (visitedDeclarations.has(path)) return;
+  visitedDeclarations.add(path);
+  const source = scannableSource(path);
+  for (const match of source.matchAll(importPattern)) {
+    const specifier = match[1];
+    const candidate = resolve(dirname(path), specifier).replace(/\.js$/u, ".d.ts");
+    if (!insideDist(candidate)) {
+      throw new Error(
+        `declaration import escapes dist: ${relative(distRoot, path)} -> ${specifier}`,
+      );
+    }
+    if (!existsSync(candidate)) {
+      throw new Error(
+        `missing declaration for import: ${relative(distRoot, path)} -> ${specifier}`,
+      );
+    }
+    visitDeclaration(candidate);
+  }
+}
+
+visit(resolve(distRoot, "tools-entry.js"));
+for (const source of [...visited]) {
+  const declaration = source.replace(/\.js$/u, ".d.ts");
+  if (existsSync(declaration)) visitDeclaration(declaration);
+}
+
+guardTarget();
+rmSync(targetRoot, { recursive: true, force: true });
+mkdirSync(targetDist, { recursive: true });
+
+const staged = [...new Set([...visited, ...visitedDeclarations])].sort();
+for (const source of staged) {
+  const destination = resolve(targetDist, relative(distRoot, source));
+  mkdirSync(dirname(destination), { recursive: true });
+  cpSync(source, destination);
+}
+
+cpSync(resolve(pluginRoot, "package.tools.json"), resolve(targetRoot, "package.json"));
+cpSync(
+  resolve(pluginRoot, "openclaw.tools.plugin.json"),
+  resolve(targetRoot, "openclaw.plugin.json"),
+);
+cpSync(resolve(pluginRoot, "README.tools.md"), resolve(targetRoot, "README.md"));
+console.log(
+  `staged ${visited.size} runtime modules (+${visitedDeclarations.size} declarations) in ${targetRoot}`,
+);

--- a/plugin/stage-tools.mjs
+++ b/plugin/stage-tools.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { stageArtifact } from "./stage-artifact.mjs";
+
+try {
+  stageArtifact({
+    targetArg: process.argv[2],
+    entry: "tools-entry.js",
+    packageFile: "package.tools.json",
+    manifestFile: "openclaw.tools.plugin.json",
+    readmeFile: "README.tools.md",
+    extraDirectories: ["skills"],
+    label: "tools",
+  });
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/plugin/test/channel-actions.test.ts
+++ b/plugin/test/channel-actions.test.ts
@@ -7,11 +7,6 @@ import {
 } from "../src/channel-actions.js";
 import { ClawBitsError } from "../src/errors.js";
 
-// ---------------------------------------------------------------------------
-// helpers — same shape as plugin.test.ts, intentionally duplicated to keep
-// this test file standalone.
-// ---------------------------------------------------------------------------
-
 function cfgWith(section: Record<string, unknown>): OpenClawConfig {
   return { channels: { clawbits: section } };
 }
@@ -19,128 +14,67 @@ function cfgWith(section: Record<string, unknown>): OpenClawConfig {
 function configuredSection(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     endpoint: "http://h",
-    orgId: "user-1",
+    orgId: "org-1",
     agentId: "a1",
     apiKey: "k1",
     channelId: "ch1",
+    knownAnswers: { "What is the capital of France?": "Paris" },
     ...overrides,
   };
 }
 
-const CHALLENGE_QUESTION = "What is the capital of France?";
-
 function challengeResponse(): Response {
   return new Response(
-    JSON.stringify({ session_token: "sess-1", challenge: CHALLENGE_QUESTION }),
+    JSON.stringify({
+      session_token: "sess-1",
+      challenge: "What is the capital of France?",
+    }),
     { status: 200, headers: { "Content-Type": "application/json" } },
   );
 }
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
-    status,
+    status: 200,
     headers: { "Content-Type": "application/json" },
   });
 }
 
-// ---------------------------------------------------------------------------
-// describeMessageTool
-// ---------------------------------------------------------------------------
-
 describe("describeClawBitsMessageTool", () => {
-  it("advertises react, reactions, update_description, and send_email actions", () => {
+  it("advertises only channel-owned reaction actions", () => {
     const out = describeClawBitsMessageTool({
       cfg: cfgWith(configuredSection()),
       accountId: null,
     });
-    assert.deepEqual(out.actions, [
-      "react",
-      "reactions",
-      "update_description",
-      "send_email",
-    ]);
-  });
-
-  it("exposes a schema fragment scoped to send_email", () => {
-    const out = describeClawBitsMessageTool({
-      cfg: cfgWith(configuredSection()),
-      accountId: null,
-    });
-    const schema = out.schema as Array<{
-      actions?: readonly string[] | null;
-      properties: Record<string, unknown>;
-    }>;
-    const frag = schema.find(
-      (s) => Array.isArray(s.actions) && s.actions.includes("send_email"),
-    );
-    assert.ok(frag, "schema contains a send_email fragment");
-    assert.ok(frag!.properties.subject, "subject field exposed");
-    assert.ok(frag!.properties.message, "message field exposed");
-  });
-
-  it("returns a schema fragment scoped to the reaction actions", () => {
-    const out = describeClawBitsMessageTool({
-      cfg: cfgWith(configuredSection()),
-      accountId: null,
-    });
-    const schema = out.schema;
-    assert.ok(Array.isArray(schema), "schema is an array of contributions");
-    const reactionFragment = schema.find(
-      (s: { actions?: readonly string[] | null }) =>
-        Array.isArray(s.actions) && s.actions.includes("react"),
-    );
-    assert.ok(reactionFragment, "schema contains a fragment scoped to react");
-    assert.deepEqual(reactionFragment.actions, ["react", "reactions"]);
-    assert.ok(
-      reactionFragment.properties.messageId,
-      "messageId field is exposed for the reaction actions",
-    );
-    assert.ok(
-      reactionFragment.properties.emoji,
-      "emoji field is exposed for the react action",
-    );
-
-    const descriptionFragment = schema.find(
-      (s: { actions?: readonly string[] | null }) =>
-        Array.isArray(s.actions) && s.actions.includes("update_description"),
-    );
-    assert.ok(descriptionFragment, "schema contains a fragment scoped to update_description");
-    assert.ok(
-      descriptionFragment.properties.description,
-      "description field is exposed for the update_description action",
-    );
+    assert.deepEqual(out.actions, ["react", "reactions"]);
+    assert.equal(out.schema?.length, 1);
+    assert.deepEqual(out.schema?.[0]?.actions, ["react", "reactions"]);
+    assert.ok(out.schema?.[0]?.properties.messageId);
+    assert.ok(out.schema?.[0]?.properties.emoji);
   });
 });
 
-// ---------------------------------------------------------------------------
-// createClawBitsActions().handleAction — react
-// ---------------------------------------------------------------------------
-
-describe("clawbitsActions.handleAction react", () => {
+describe("clawbits channel reactions", () => {
   const adapter = createClawBitsActions();
   if (!adapter.handleAction) throw new Error("handleAction missing");
   const handleAction = adapter.handleAction as (ctx: unknown) => Promise<unknown>;
 
-  it("calls /api/agentic/mm/posts/{id}/reactions with the supplied emoji", async () => {
+  it("toggles a reaction", async () => {
     const originalFetch = globalThis.fetch;
-    const captured: { url: string; method: string; body: string }[] = [];
+    const captured: Array<{ method: string; body: string }> = [];
     globalThis.fetch = (async (url, init) => {
-      const u = String(url);
-      const method = init?.method ?? "GET";
-      const body = typeof init?.body === "string" ? init.body : "";
-      if (u.endsWith("/api/agentic/auth/challenge")) {
-        return challengeResponse();
-      }
-      if (u.endsWith("/api/agentic/mm/posts/42/reactions")) {
-        captured.push({ url: u, method, body });
+      const target = String(url);
+      if (target.endsWith("/api/agentic/auth/challenge")) return challengeResponse();
+      if (target.endsWith("/api/agentic/mm/posts/42/reactions")) {
+        captured.push({
+          method: init?.method ?? "GET",
+          body: typeof init?.body === "string" ? init.body : "",
+        });
         return jsonResponse({
-          post_id: 42,
-          reactions: [
-            { emoji: "🎉", count: 1, agent_ids: ["a1"], human_ids: [] },
-          ],
+          reactions: [{ emoji: "🎉", count: 1, agent_ids: ["a1"], human_ids: [] }],
         });
       }
-      return new Response(`unexpected: ${u}`, { status: 500 });
+      return new Response(`unexpected: ${target}`, { status: 500 });
     }) as typeof fetch;
 
     try {
@@ -150,119 +84,36 @@ describe("clawbitsActions.handleAction react", () => {
         cfg: cfgWith(configuredSection()),
         params: { messageId: "42", emoji: "🎉" },
       })) as { ok: boolean; data: Record<string, unknown> };
-
-      assert.equal(captured.length, 1, "exactly one POST to /reactions");
-      assert.equal(captured[0]!.method, "POST");
-      assert.deepEqual(JSON.parse(captured[0]!.body), { emoji: "🎉" });
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0]?.method, "POST");
+      assert.deepEqual(JSON.parse(captured[0]?.body ?? "{}"), { emoji: "🎉" });
       assert.equal(result.ok, true);
-      assert.equal(result.data.action, "react");
-      assert.equal(result.data.messageId, "42");
-      // After the toggle our agent is in the bucket → "added".
-      assert.equal((result.data as { added?: string }).added, "🎉");
+      assert.equal(result.data.added, "🎉");
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  it("accepts message_id (snake_case) as an alias for messageId", async () => {
+  it("uses a second toggle for remove=true when needed", async () => {
     const originalFetch = globalThis.fetch;
-    let postedTo = "";
-    globalThis.fetch = (async (url, init) => {
-      const u = String(url);
-      if (u.endsWith("/api/agentic/auth/challenge")) {
-        return challengeResponse();
-      }
-      if (u.includes("/api/agentic/mm/posts/") && u.endsWith("/reactions")) {
-        postedTo = u;
-        return jsonResponse({ reactions: [] });
-      }
-      return new Response(`unexpected: ${u}`, { status: 500 });
-    }) as typeof fetch;
-
-    try {
-      await handleAction({
-        channel: "clawbits",
-        action: "react",
-        cfg: cfgWith(configuredSection()),
-        params: { message_id: "99", emoji: "👍" },
-      });
-      assert.ok(
-        postedTo.endsWith("/api/agentic/mm/posts/99/reactions"),
-        `posted to id-99 endpoint: ${postedTo}`,
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it("rejects when messageId is missing", async () => {
-    await assert.rejects(
-      () =>
-        handleAction({
-          channel: "clawbits",
-          action: "react",
-          cfg: cfgWith(configuredSection()),
-          params: { emoji: "🎉" },
-        }),
-      (err: unknown) =>
-        err instanceof ClawBitsError && /messageId/.test(err.detail as string),
-    );
-  });
-
-  it("rejects when emoji is missing", async () => {
-    await assert.rejects(
-      () =>
-        handleAction({
-          channel: "clawbits",
-          action: "react",
-          cfg: cfgWith(configuredSection()),
-          params: { messageId: "42" },
-        }),
-      (err: unknown) =>
-        err instanceof ClawBitsError && /Emoji/.test(err.detail as string),
-    );
-  });
-
-  it("rejects when the account is disabled", async () => {
-    await assert.rejects(
-      () =>
-        handleAction({
-          channel: "clawbits",
-          action: "react",
-          cfg: cfgWith({ ...configuredSection(), enabled: false }),
-          params: { messageId: "42", emoji: "🎉" },
-        }),
-      (err: unknown) =>
-        err instanceof ClawBitsError && /disabled/.test(err.detail as string),
-    );
-  });
-
-  it("issues a second toggle when remove=true and the agent is still present", async () => {
-    const originalFetch = globalThis.fetch;
-    let toggleCalls = 0;
+    let calls = 0;
     globalThis.fetch = (async (url) => {
-      const u = String(url);
-      if (u.endsWith("/api/agentic/auth/challenge")) {
-        return challengeResponse();
-      }
-      if (u.endsWith("/api/agentic/mm/posts/42/reactions")) {
-        toggleCalls += 1;
-        // First call: agent now appears in the bucket. Second call:
-        // agent is gone (toggled off again).
-        if (toggleCalls === 1) {
-          return jsonResponse({
-            reactions: [
-              { emoji: "🎉", count: 1, agent_ids: ["a1"], human_ids: [] },
-            ],
-          });
-        }
+      const target = String(url);
+      if (target.endsWith("/api/agentic/auth/challenge")) return challengeResponse();
+      if (target.endsWith("/api/agentic/mm/posts/42/reactions")) {
+        calls += 1;
         return jsonResponse({
           reactions: [
-            { emoji: "🎉", count: 0, agent_ids: [], human_ids: [] },
+            {
+              emoji: "🎉",
+              count: calls === 1 ? 1 : 0,
+              agent_ids: calls === 1 ? ["a1"] : [],
+              human_ids: [],
+            },
           ],
         });
       }
-      return new Response(`unexpected: ${u}`, { status: 500 });
+      return new Response(`unexpected: ${target}`, { status: 500 });
     }) as typeof fetch;
 
     try {
@@ -272,361 +123,62 @@ describe("clawbitsActions.handleAction react", () => {
         cfg: cfgWith(configuredSection()),
         params: { messageId: "42", emoji: "🎉", remove: true },
       })) as { data: Record<string, unknown> };
-      assert.equal(toggleCalls, 2, "remove=true triggers a second toggle");
+      assert.equal(calls, 2);
       assert.equal(result.data.removed, "🎉");
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
-});
 
-// ---------------------------------------------------------------------------
-// createClawBitsActions().handleAction — update_description
-// ---------------------------------------------------------------------------
-
-describe("clawbitsActions.handleAction update_description", () => {
-  const adapter = createClawBitsActions();
-  if (!adapter.handleAction) throw new Error("handleAction missing");
-  const handleAction = adapter.handleAction as (ctx: unknown) => Promise<unknown>;
-
-  it("updates the agent profile description through the Clawbits API", async () => {
-    const originalFetch = globalThis.fetch;
-    const captured: { url: string; method: string; body: string; authorization?: string }[] = [];
-    globalThis.fetch = (async (url, init) => {
-      const u = String(url);
-      const method = init?.method ?? "GET";
-      const body = typeof init?.body === "string" ? init.body : "";
-      const headers = init?.headers as Record<string, string> | undefined;
-      if (u.endsWith("/api/agentic/agents/a1/description")) {
-        captured.push({
-          url: u,
-          method,
-          body,
-          authorization: headers?.Authorization,
-        });
-        return jsonResponse({
-          agent_id: "a1",
-          description: "I help review code.",
-          description_source: "auto",
-          description_generated_at: "2026-06-10T12:00:00Z",
-        });
-      }
-      return new Response(`unexpected: ${u}`, { status: 500 });
-    }) as typeof fetch;
-
-    try {
-      const result = (await handleAction({
-        channel: "clawbits",
-        action: "update_description",
-        cfg: cfgWith(configuredSection()),
-        params: { description: "I help review code." },
-      })) as { ok: boolean; data: Record<string, unknown> };
-
-      assert.equal(captured.length, 1, "exactly one PUT to /description");
-      assert.equal(captured[0]!.method, "PUT");
-      assert.equal(captured[0]!.authorization, "Bearer k1");
-      assert.deepEqual(JSON.parse(captured[0]!.body), { description: "I help review code." });
-      assert.equal(result.ok, true);
-      assert.equal(result.data.action, "update_description");
-      assert.equal(result.data.agentId, "a1");
-      assert.equal(result.data.description, "I help review code.");
-      assert.equal(result.data.description_source, "auto");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it("rejects when description is missing", async () => {
-    await assert.rejects(
-      () =>
-        handleAction({
-          channel: "clawbits",
-          action: "update_description",
-          cfg: cfgWith(configuredSection()),
-          params: {},
-        }),
-      (err: unknown) =>
-        err instanceof ClawBitsError && /description/.test(err.detail as string),
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// createClawBitsActions().handleAction — reactions
-// ---------------------------------------------------------------------------
-
-describe("clawbitsActions.handleAction reactions", () => {
-  const adapter = createClawBitsActions();
-  if (!adapter.handleAction) throw new Error("handleAction missing");
-  const handleAction = adapter.handleAction as (ctx: unknown) => Promise<unknown>;
-
-  it("returns the reaction aggregate from the post listing", async () => {
+  it("reads reactions from the configured channel", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async (url) => {
-      const u = String(url);
-      if (u.endsWith("/api/agentic/mm/channels/ch1/posts")) {
-        return jsonResponse({
-          posts: [
-            {
-              post_id: 41,
-              reactions: [{ emoji: "✨", count: 2, agent_ids: ["x"] }],
-            },
-            {
-              post_id: 42,
-              reactions: [{ emoji: "🎉", count: 1, agent_ids: ["a1"] }],
-            },
-          ],
-        });
-      }
-      return new Response(`unexpected: ${u}`, { status: 500 });
+      const target = String(url);
+      assert.ok(target.endsWith("/api/agentic/mm/channels/ch1/posts"));
+      return jsonResponse({
+        posts: [{ post_id: 42, reactions: [{ emoji: "👍", count: 2 }] }],
+      });
     }) as typeof fetch;
-
     try {
       const result = (await handleAction({
         channel: "clawbits",
         action: "reactions",
         cfg: cfgWith(configuredSection()),
         params: { messageId: "42" },
-      })) as { ok: boolean; data: { reactions: Array<{ emoji: string }> } };
-      assert.equal(result.ok, true);
-      assert.equal(result.data.reactions.length, 1);
-      assert.equal(result.data.reactions[0]!.emoji, "🎉");
+      })) as { data: Record<string, unknown> };
+      assert.deepEqual(result.data.reactions, [{ emoji: "👍", count: 2 }]);
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  it("returns an empty list when the post id is not in the listing", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async (url) => {
-      const u = String(url);
-      if (u.endsWith("/api/agentic/mm/channels/ch1/posts")) {
-        return jsonResponse({ posts: [] });
-      }
-      return new Response(`unexpected: ${u}`, { status: 500 });
-    }) as typeof fetch;
-
-    try {
-      const result = (await handleAction({
-        channel: "clawbits",
-        action: "reactions",
-        cfg: cfgWith(configuredSection()),
-        params: { messageId: "999" },
-      })) as { data: { reactions: unknown[] } };
-      assert.deepEqual(result.data.reactions, []);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it("rejects when no channelId is configured", async () => {
+  it("rejects missing params and disabled accounts", async () => {
     await assert.rejects(
       () =>
         handleAction({
           channel: "clawbits",
-          action: "reactions",
-          cfg: cfgWith({
-            endpoint: "http://h",
-            orgId: "user-1",
-            agentId: "a1",
-            apiKey: "k1",
-            // no channelId
-          }),
-          params: { messageId: "42" },
-        }),
-      (err: unknown) =>
-        err instanceof ClawBitsError && /channelId/.test(err.detail as string),
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// supportsAction
-// ---------------------------------------------------------------------------
-
-describe("clawbitsActions.supportsAction", () => {
-  const adapter = createClawBitsActions();
-  if (!adapter.supportsAction) throw new Error("supportsAction missing");
-  const supports = adapter.supportsAction as (params: { action: string }) => boolean;
-
-  it("returns true for react / reactions / update_description", () => {
-    assert.equal(supports({ action: "react" }), true);
-    assert.equal(supports({ action: "reactions" }), true);
-    assert.equal(supports({ action: "update_description" }), true);
-  });
-
-  it("returns false for unrelated actions", () => {
-    assert.equal(supports({ action: "send" }), false);
-    assert.equal(supports({ action: "edit" }), false);
-    assert.equal(supports({ action: "delete" }), false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// channelPlugin wiring
-// ---------------------------------------------------------------------------
-
-describe("clawbitsChannelPlugin.actions", () => {
-  it("is registered on the channel plugin", async () => {
-    const { clawbitsChannelPlugin } = await import("../src/plugin.js");
-    const actions = (clawbitsChannelPlugin as unknown as { actions?: unknown }).actions;
-    assert.ok(actions, "actions slot is populated");
-    assert.equal(typeof (actions as { describeMessageTool?: unknown }).describeMessageTool, "function");
-    assert.equal(typeof (actions as { handleAction?: unknown }).handleAction, "function");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// createClawBitsActions().handleAction — send_email
-// ---------------------------------------------------------------------------
-
-describe("clawbitsActions.handleAction send_email", () => {
-  const adapter = createClawBitsActions();
-  if (!adapter.handleAction) throw new Error("handleAction missing");
-  const handleAction = adapter.handleAction as (ctx: unknown) => Promise<unknown>;
-
-  it("POSTs subject/message (+attachments) to /email/send with a challenge", async () => {
-    const originalFetch = globalThis.fetch;
-    const captured: { url: string; method: string; body: string; headers: Record<string, string> }[] = [];
-    globalThis.fetch = (async (url, init) => {
-      const u = String(url);
-      const method = init?.method ?? "GET";
-      const body = typeof init?.body === "string" ? init.body : "";
-      const headers = (init?.headers ?? {}) as Record<string, string>;
-      if (u.endsWith("/api/agentic/auth/challenge")) {
-        return challengeResponse();
-      }
-      if (u.endsWith("/api/agentic/agents/a1/email/send")) {
-        captured.push({ url: u, method, body, headers });
-        return jsonResponse({
-          status: "sent",
-          from_addr: "a1@clawbits.ai",
-          to_addr: "owner@example.com",
-          subject: "Hello",
-        });
-      }
-      return new Response(`unexpected: ${u}`, { status: 500 });
-    }) as typeof fetch;
-
-    try {
-      const result = (await handleAction({
-        channel: "clawbits",
-        action: "send_email",
-        cfg: cfgWith(configuredSection()),
-        params: {
-          subject: "Hello",
-          message: "Body text",
-          attachments: [{ filename: "a.txt", content_b64: "aGk=" }],
-        },
-      })) as { ok: boolean; data: Record<string, unknown> };
-
-      assert.equal(captured.length, 1, "exactly one POST to /email/send");
-      assert.equal(captured[0]!.method, "POST");
-      const sent = JSON.parse(captured[0]!.body);
-      assert.equal(sent.subject, "Hello");
-      assert.equal(sent.message, "Body text");
-      assert.deepEqual(sent.attachments, [{ filename: "a.txt", content_b64: "aGk=" }]);
-      // Challenge headers ride the paid send.
-      assert.ok(captured[0]!.headers["session_token"], "session_token header present");
-      assert.equal(result.ok, true);
-      assert.equal(result.data.action, "send_email");
-      assert.equal(result.data.status, "sent");
-      assert.equal(result.data.to_addr, "owner@example.com");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it("mirrors the sent email into the operator DM channel (temporary)", async () => {
-    const originalFetch = globalThis.fetch;
-    const posts: { url: string; message: string }[] = [];
-    globalThis.fetch = (async (url, init) => {
-      const u = String(url);
-      const body = typeof init?.body === "string" ? init.body : "";
-      if (u.endsWith("/api/agentic/auth/challenge")) {
-        return challengeResponse();
-      }
-      if (u.endsWith("/api/agentic/agents/a1/email/send")) {
-        return jsonResponse({
-          status: "sent",
-          from_addr: "a1@clawbits.ai",
-          to_addr: "owner@example.com",
-          subject: "Hello",
-        });
-      }
-      if (u.endsWith("/api/agentic/mm/channels/ch1/posts")) {
-        const parsed = body ? JSON.parse(body) : {};
-        posts.push({ url: u, message: String(parsed.message ?? "") });
-        return jsonResponse({ id: "p1" });
-      }
-      return new Response(`unexpected: ${u}`, { status: 500 });
-    }) as typeof fetch;
-
-    try {
-      const result = (await handleAction({
-        channel: "clawbits",
-        action: "send_email",
-        cfg: cfgWith(configuredSection()),
-        params: { subject: "Hello", message: "Body text" },
-      })) as { ok: boolean; data: Record<string, unknown> };
-
-      assert.equal(result.ok, true);
-      assert.equal(posts.length, 1, "exactly one DM mirror post for the sent email");
-      assert.match(posts[0]!.url, /\/mm\/channels\/ch1\/posts$/, "mirror goes to the operator DM channel");
-      assert.match(posts[0]!.message, /Email · sent/, "mirror is labelled as a sent email");
-      assert.match(posts[0]!.message, /Hello/, "mirror carries the subject");
-      assert.match(posts[0]!.message, /Body text/, "mirror carries the message body");
-      assert.match(posts[0]!.message, /^> /m, "mirror is blockquoted to set it apart from chat");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it("still succeeds when the DM mirror fails (best-effort)", async () => {
-    const originalFetch = globalThis.fetch;
-    let sendCount = 0;
-    globalThis.fetch = (async (url) => {
-      const u = String(url);
-      if (u.endsWith("/api/agentic/auth/challenge")) {
-        return challengeResponse();
-      }
-      if (u.endsWith("/api/agentic/agents/a1/email/send")) {
-        sendCount += 1;
-        return jsonResponse({ status: "sent", to_addr: "owner@example.com", subject: "Hello" });
-      }
-      if (u.endsWith("/api/agentic/mm/channels/ch1/posts")) {
-        return new Response("mirror boom", { status: 500 });
-      }
-      return new Response(`unexpected: ${u}`, { status: 500 });
-    }) as typeof fetch;
-
-    try {
-      const result = (await handleAction({
-        channel: "clawbits",
-        action: "send_email",
-        cfg: cfgWith(configuredSection()),
-        params: { subject: "Hello", message: "Body text" },
-      })) as { ok: boolean; data: Record<string, unknown> };
-
-      assert.equal(sendCount, 1, "the email was sent");
-      assert.equal(result.ok, true, "send_email still succeeds even though the DM mirror failed");
-      assert.equal(result.data.status, "sent");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it("rejects when subject or message is missing", async () => {
-    await assert.rejects(
-      () =>
-        handleAction({
-          channel: "clawbits",
-          action: "send_email",
+          action: "react",
           cfg: cfgWith(configuredSection()),
-          params: { subject: "no body" },
+          params: { emoji: "🎉" },
         }),
-      (err: unknown) =>
-        err instanceof ClawBitsError && /message is required/.test(String(err.detail)),
+      (error: unknown) => error instanceof ClawBitsError && /messageId/.test(error.detail),
     );
+    await assert.rejects(
+      () =>
+        handleAction({
+          channel: "clawbits",
+          action: "react",
+          cfg: cfgWith(configuredSection({ enabled: false })),
+          params: { messageId: "42", emoji: "🎉" },
+        }),
+      (error: unknown) => error instanceof ClawBitsError && /disabled/.test(error.detail),
+    );
+  });
+
+  it("supports only react and reactions", () => {
+    assert.equal(adapter.supportsAction?.({ action: "react" }), true);
+    assert.equal(adapter.supportsAction?.({ action: "reactions" }), true);
+    assert.equal(adapter.supportsAction?.({ action: "send_email" }), false);
+    assert.equal(adapter.supportsAction?.({ action: "update_description" }), false);
   });
 });

--- a/plugin/test/channel-watermarks.test.ts
+++ b/plugin/test/channel-watermarks.test.ts
@@ -74,6 +74,19 @@ describe("ChannelWatermarkStore", () => {
     });
   });
 
+  it("shares one in-flight load across concurrent account pollers", async () => {
+    await withTempFile(async (path) => {
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(path, JSON.stringify({ acct: { "email:inbox": 42 } }), "utf8");
+      const store = new ChannelWatermarkStore(path);
+      const first = store.load();
+      const second = store.load();
+      assert.equal(first, second);
+      await Promise.all([first, second]);
+      assert.equal(store.get("acct", "email:inbox"), 42);
+    });
+  });
+
   it("load is idempotent (only the first call reads)", async () => {
     await withTempFile(async (path) => {
       const { writeFile } = await import("node:fs/promises");
@@ -86,5 +99,51 @@ describe("ChannelWatermarkStore", () => {
       await store.load();
       assert.equal(store.get("acct", "chan"), 42);
     });
+  });
+
+  it("migrates only email progress into a separately owned state file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawbits-email-wm-"));
+    try {
+      const legacyPath = join(dir, "clawbits-channel-state.json");
+      const emailPath = join(dir, "clawbits-email-state.json");
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(
+        legacyPath,
+        JSON.stringify({ acct: { room: 100, "cursor:room": 90, "email:inbox": 77 } }),
+        "utf8",
+      );
+      const email = new ChannelWatermarkStore(emailPath, {
+        migrationPath: legacyPath,
+        migrationChannelId: "email:inbox",
+      });
+      await email.load();
+      assert.equal(email.get("acct", "email:inbox"), 77);
+      assert.equal(email.get("acct", "room"), undefined);
+      await email.flush();
+      assert.deepEqual(JSON.parse(await readFile(emailPath, "utf8")), {
+        acct: { "email:inbox": 77 },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers existing companion email state over legacy state", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawbits-email-wm-"));
+    try {
+      const legacyPath = join(dir, "legacy.json");
+      const emailPath = join(dir, "email.json");
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(legacyPath, JSON.stringify({ acct: { "email:inbox": 77 } }), "utf8");
+      await writeFile(emailPath, JSON.stringify({ acct: { "email:inbox": 99 } }), "utf8");
+      const email = new ChannelWatermarkStore(emailPath, {
+        migrationPath: legacyPath,
+        migrationChannelId: "email:inbox",
+      });
+      await email.load();
+      assert.equal(email.get("acct", "email:inbox"), 99);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugin/test/staging.test.ts
+++ b/plugin/test/staging.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = fileURLToPath(new URL("..", import.meta.url));
+
+function allFiles(root: string, current = root): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(current)) {
+    const path = join(current, entry);
+    if (statSync(path).isDirectory()) files.push(...allFiles(root, path));
+    else files.push(relative(root, path));
+  }
+  return files.sort();
+}
+
+function stage(script: string, target: string): void {
+  execFileSync(process.execPath, [join(pluginRoot, script), target], {
+    cwd: pluginRoot,
+    stdio: "pipe",
+  });
+}
+
+describe("standalone package staging", () => {
+  it("builds disjoint channel and companion closures", () => {
+    const temp = mkdtempSync(join(tmpdir(), "clawbits-stage-"));
+    try {
+      execFileSync("bun", ["run", "build"], { cwd: pluginRoot, stdio: "pipe" });
+      const channel = join(temp, "channel");
+      const tools = join(temp, "tools");
+      stage("stage-channel.mjs", channel);
+      stage("stage-tools.mjs", tools);
+      const channelFiles = allFiles(channel);
+      const toolsFiles = allFiles(tools);
+
+      assert.ok(channelFiles.includes("dist/index.js"));
+      assert.ok(channelFiles.includes("openclaw.plugin.json"));
+      assert.ok(!channelFiles.some((path) => path.startsWith("src/")));
+      assert.ok(!channelFiles.some((path) => path.startsWith("skills/")));
+      for (const moved of [
+        "dist/tools-entry.js",
+        "dist/companion-services.js",
+        "dist/automations/reconcile.js",
+        "dist/email-poller.js",
+        "dist/usage/reporter.js",
+        "dist/skills/sync.js",
+      ]) {
+        assert.ok(!channelFiles.includes(moved), `${moved} excluded from channel`);
+      }
+
+      assert.ok(toolsFiles.includes("dist/tools-entry.js"));
+      assert.ok(toolsFiles.includes("dist/companion-services.js"));
+      assert.ok(toolsFiles.includes("dist/automations/reconcile.js"));
+      assert.ok(toolsFiles.includes("dist/email-poller.js"));
+      assert.ok(toolsFiles.includes("dist/usage/reporter.js"));
+      assert.ok(toolsFiles.includes("dist/skills/sync.js"));
+      assert.ok(toolsFiles.some((path) => path.startsWith("skills/")));
+      assert.ok(!toolsFiles.some((path) => path.startsWith("src/")));
+      for (const channelOnly of [
+        "dist/index.js",
+        "dist/plugin.js",
+        "dist/gateway-adapter.js",
+        "dist/inbound-poller.js",
+        "dist/channel-actions.js",
+        "dist/cli.js",
+      ]) {
+        assert.ok(!toolsFiles.includes(channelOnly), `${channelOnly} excluded from companion`);
+      }
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugin/test/staging.test.ts
+++ b/plugin/test/staging.test.ts
@@ -26,7 +26,7 @@ function stage(script: string, target: string): void {
 }
 
 describe("standalone package staging", () => {
-  it("builds disjoint channel and companion closures", () => {
+  it("builds disjoint channel and companion closures", { timeout: 30_000 }, () => {
     const temp = mkdtempSync(join(tmpdir(), "clawbits-stage-"));
     try {
       execFileSync("bun", ["run", "build"], { cwd: pluginRoot, stdio: "pipe" });

--- a/plugin/test/tools-entry.test.ts
+++ b/plugin/test/tools-entry.test.ts
@@ -1,0 +1,331 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  getToolPluginMetadata,
+  type DefinedToolPluginTool,
+  type ToolPluginApi,
+} from "openclaw/plugin-sdk/tool-plugin";
+import toolsEntry, { CLAWBITS_TOOL_NAMES } from "../src/tools-entry.js";
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(new URL(path, import.meta.url), "utf8")) as Record<string, unknown>;
+}
+
+/** Numeric dotted-version compare (OpenClaw uses YYYY.M.PATCH). */
+function compareVersions(a: string, b: string): number {
+  const left = a.split(".").map(Number);
+  const right = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+const DEFAULT_ACCOUNT = {
+  endpoint: "https://app.clawbits.test",
+  orgId: "org-1",
+  agentId: "agent-1",
+  apiKey: "secret-key",
+  channelId: "channel-1",
+};
+
+function apiWithClawBitsSection(
+  section: Record<string, unknown>,
+  registerTool: (tool: DefinedToolPluginTool) => void = () => {},
+): ToolPluginApi {
+  return {
+    config: { channels: { clawbits: section } },
+    registerTool,
+  };
+}
+
+function configuredApi(registerTool: (tool: DefinedToolPluginTool) => void): ToolPluginApi {
+  return apiWithClawBitsSection({ accounts: { default: { ...DEFAULT_ACCOUNT } } }, registerTool);
+}
+
+function registeredTools(api?: ToolPluginApi): DefinedToolPluginTool[] {
+  const tools: DefinedToolPluginTool[] = [];
+  toolsEntry.register(api ?? configuredApi((tool) => tools.push(tool)));
+  return tools;
+}
+
+function findTool(name: (typeof CLAWBITS_TOOL_NAMES)[number]): DefinedToolPluginTool {
+  const tool = registeredTools().find((candidate) => candidate.name === name);
+  assert.ok(tool?.execute, `tool ${name} with execute`);
+  return tool;
+}
+
+function executionContext(api: ToolPluginApi, signal?: AbortSignal) {
+  return {
+    api,
+    toolCallId: "tool-call-1",
+    ...(signal ? { signal } : {}),
+  };
+}
+
+/** Run one tool against a mocked global fetch; returns the result and the fetch call's init. */
+async function callWithMockedFetch(
+  tool: DefinedToolPluginTool,
+  params: Record<string, unknown>,
+  api: ToolPluginApi,
+  respond: (input: unknown, init?: RequestInit) => Response,
+): Promise<{ result: unknown; init: RequestInit | undefined }> {
+  const originalFetch = globalThis.fetch;
+  let seenInit: RequestInit | undefined;
+  try {
+    globalThis.fetch = async (input, init) => {
+      seenInit = init;
+      return respond(input, init);
+    };
+    const result = await tool.execute!(params, {}, executionContext(api));
+    return { result, init: seenInit };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe("clawbits tools plugin", () => {
+  it("declares stable optional tools matching the publish manifest", () => {
+    const metadata = getToolPluginMetadata(toolsEntry);
+    assert.ok(metadata);
+    assert.equal(metadata.id, "clawbits-tools");
+    assert.deepEqual(metadata.tools.map((tool) => tool.name), [...CLAWBITS_TOOL_NAMES]);
+    assert.ok(metadata.tools.every((tool) => tool.optional));
+
+    const manifest = readJson("../openclaw.tools.plugin.json") as {
+      contracts?: { tools?: string[] };
+      toolMetadata?: Record<string, { optional?: boolean }>;
+    };
+    assert.deepEqual(manifest.contracts?.tools, [...CLAWBITS_TOOL_NAMES]);
+    assert.deepEqual(Object.keys(manifest.toolMetadata ?? {}), [...CLAWBITS_TOOL_NAMES]);
+    assert.ok(Object.values(manifest.toolMetadata ?? {}).every((tool) => tool.optional === true));
+  });
+
+  it("publishes a separate built entry", () => {
+    const pkg = readJson("../package.tools.json") as {
+      name?: string;
+      version?: string;
+      dependencies?: Record<string, string>;
+      openclaw?: { id?: string; extensions?: string[]; runtimeExtensions?: string[] };
+    };
+    const channelPkg = readJson("../package.json") as { version?: string };
+    assert.equal(pkg.name, "clawbits-openclaw-tools");
+    assert.equal(
+      pkg.version?.split(".").slice(0, 2).join("."),
+      channelPkg.version?.split(".").slice(0, 2).join("."),
+      "both clients send X-Clawbits-Plugin-Version and must share a release line",
+    );
+    assert.equal(pkg.openclaw?.id, "clawbits-tools");
+    assert.deepEqual(pkg.openclaw?.extensions, ["./dist/tools-entry.js"]);
+    assert.deepEqual(pkg.openclaw?.runtimeExtensions, ["./dist/tools-entry.js"]);
+    assert.ok(pkg.dependencies?.["typebox"], "staged artifact must declare its runtime import");
+  });
+
+  it("declares one consistent OpenClaw compatibility floor", () => {
+    const pkg = readJson("../package.tools.json") as {
+      peerDependencies?: Record<string, string>;
+      openclaw?: {
+        compat?: { pluginApi?: string; minGatewayVersion?: string };
+        build?: { openclawVersion?: string };
+      };
+    };
+    const floor = pkg.openclaw?.compat?.minGatewayVersion;
+    const build = pkg.openclaw?.build?.openclawVersion;
+    assert.ok(floor);
+    assert.ok(build);
+    // Three copies of one number. The publish workflow validates the floor and
+    // the build SDK, so a drifted copy would advertise support the pipeline
+    // never exercises — how this package ended up inheriting the channel's
+    // 2026.6.10 for an SDK surface the channel never imports.
+    assert.equal(pkg.openclaw?.compat?.pluginApi, `>=${floor}`);
+    assert.equal(pkg.peerDependencies?.["openclaw"], `>=${floor}`);
+    assert.ok(
+      compareVersions(floor, build) <= 0,
+      "compat floor cannot exceed the SDK the artifact is built against",
+    );
+  });
+
+  it("pins tools compatibility to Reef's reviewed OpenClaw floor", () => {
+    // Changing either side requires an explicit compatibility review. This
+    // prevents a package-only floor bump from silently breaking Reef and a
+    // Reef-only runtime bump from silently dropping older supported installs.
+    const expectedFloor = "2026.6.10";
+    const dockerfile = readFileSync(
+      new URL("../../reef/images/openclaw-runtime/Dockerfile", import.meta.url),
+      "utf8",
+    );
+    const reefVersion = /^ARG OPENCLAW_VERSION=(\S+)/mu.exec(dockerfile)?.[1];
+    assert.equal(reefVersion, expectedFloor, "review tools compatibility when Reef changes");
+
+    const pkg = readJson("../package.tools.json") as {
+      openclaw?: { compat?: { minGatewayVersion?: string } };
+    };
+    assert.equal(
+      pkg.openclaw?.compat?.minGatewayVersion,
+      expectedFloor,
+      "review Reef compatibility before changing the tools floor",
+    );
+  });
+
+  it("ships no channel surface in the entry or either manifest", () => {
+    // Assert on the shipped artifacts, not on stub behavior: the entry object
+    // carries no channel plugin, and neither manifest declares channels or
+    // skills — the channel package is the only one allowed to.
+    assert.ok(!("channelPlugin" in toolsEntry));
+    const pkg = readJson("../package.tools.json") as {
+      openclaw?: Record<string, unknown>;
+    };
+    assert.equal(pkg.openclaw?.["channels"], undefined);
+    assert.equal(pkg.openclaw?.["skills"], undefined);
+    const manifest = readJson("../openclaw.tools.plugin.json");
+    assert.equal(manifest["channels"], undefined);
+    assert.equal(manifest["skills"], undefined);
+
+    const tools: DefinedToolPluginTool[] = [];
+    let channelRegistrations = 0;
+    toolsEntry.register({
+      ...configuredApi((tool) => tools.push(tool)),
+      registerChannel: () => {
+        channelRegistrations += 1;
+      },
+    });
+    assert.deepEqual(tools.map((tool) => tool.name), [...CLAWBITS_TOOL_NAMES]);
+    assert.equal(channelRegistrations, 0);
+  });
+
+  it("uses the channel account config without exposing its API key", async () => {
+    const listTool = findTool("clawbits_channels_list");
+    let authorization = "";
+    const { result, init } = await callWithMockedFetch(
+      listTool,
+      {},
+      configuredApi(() => {}),
+      (input, requestInit) => {
+        authorization = new Headers(requestInit?.headers).get("Authorization") ?? "";
+        assert.equal(String(input), "https://app.clawbits.test/api/agentic/mm/channels");
+        return new Response(JSON.stringify([{ channel_id: "channel-1" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+    assert.deepEqual(result, [{ channel_id: "channel-1" }]);
+    assert.equal(authorization, "Bearer secret-key");
+    assert.ok(!JSON.stringify(result).includes("secret-key"));
+    assert.ok(init?.signal instanceof AbortSignal, "every tool request is abortable/bounded");
+  });
+
+  it("fails clearly when the channel account is missing", async () => {
+    const infoTool = findTool("clawbits_agent_info");
+    await assert.rejects(
+      async () =>
+        infoTool.execute!({}, {}, executionContext({ config: {} })),
+      /channel plugin first/,
+    );
+  });
+
+  it("rejects an accountId that names no configured account instead of falling back", async () => {
+    const infoTool = findTool("clawbits_agent_info");
+    // Inline creds plus named accounts: a typo'd id must not silently resolve
+    // to the inline account's mailbox.
+    const api = apiWithClawBitsSection({
+      ...DEFAULT_ACCOUNT,
+      accounts: { work: { ...DEFAULT_ACCOUNT, agentId: "agent-work" } },
+    });
+    await assert.rejects(
+      async () => infoTool.execute!({ accountId: "wrok" }, {}, executionContext(api)),
+      /Unknown Clawbits account 'wrok'/,
+    );
+  });
+
+  it("honors the account enabled kill switch", async () => {
+    const listTool = findTool("clawbits_channels_list");
+    const api = apiWithClawBitsSection({
+      accounts: { default: { ...DEFAULT_ACCOUNT, enabled: false } },
+    });
+    await assert.rejects(
+      async () => listTool.execute!({}, {}, executionContext(api)),
+      /disabled/,
+    );
+  });
+
+  it("honors emailEnabled for email tools while non-email tools keep working", async () => {
+    const api = () =>
+      apiWithClawBitsSection({
+        accounts: { default: { ...DEFAULT_ACCOUNT, emailEnabled: false } },
+      });
+    for (const name of ["clawbits_email_inbox", "clawbits_email_get"] as const) {
+      const tool = findTool(name);
+      await assert.rejects(
+        async () =>
+          tool.execute!(
+            name === "clawbits_email_get" ? { messageUid: 1 } : {},
+            {},
+            executionContext(api()),
+          ),
+        /email integration is disabled/,
+      );
+    }
+    const listTool = findTool("clawbits_channels_list");
+    const { result } = await callWithMockedFetch(
+      listTool,
+      {},
+      api(),
+      () => new Response("[]", { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+    assert.deepEqual(result, []);
+  });
+
+  it("strips attachment bodies from email reads", async () => {
+    const getTool = findTool("clawbits_email_get");
+    const payload = {
+      uid: 7,
+      subject: "invoice",
+      body_text: "see attached",
+      attachments: [
+        { filename: "big.pdf", content_type: "application/pdf", content_b64: "A".repeat(8000) },
+      ],
+    };
+    const { result } = await callWithMockedFetch(
+      getTool,
+      { messageUid: 7 },
+      configuredApi(() => {}),
+      (input) => {
+        assert.equal(
+          String(input),
+          "https://app.clawbits.test/api/agentic/agents/agent-1/email/7",
+        );
+        return new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+    const detail = result as {
+      attachments?: Array<Record<string, unknown>>;
+      attachments_note?: string;
+      body_text?: string;
+    };
+    assert.equal(detail.body_text, "see attached");
+    assert.ok(!JSON.stringify(result).includes("AAAA"), "no base64 body in tool output");
+    assert.deepEqual(detail.attachments, [
+      { filename: "big.pdf", content_type: "application/pdf", size: 6000 },
+    ]);
+    assert.ok(detail.attachments_note);
+  });
+
+  it("refuses to run when the runtime signal is already aborted", async () => {
+    const listTool = findTool("clawbits_channels_list");
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+    await assert.rejects(async () =>
+      listTool.execute!(
+        {},
+        {},
+        executionContext(configuredApi(() => {}), controller.signal),
+      ),
+    );
+  });
+});

--- a/plugin/test/tools-entry.test.ts
+++ b/plugin/test/tools-entry.test.ts
@@ -1,0 +1,528 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import type {
+  OpenClawPluginApi,
+  StubAgentTool,
+} from "openclaw/plugin-sdk/plugin-entry";
+import toolsEntry, { CLAWBITS_TOOL_NAMES } from "../src/tools-entry.js";
+import { resolveCompanionServiceActivation } from "../src/companion-services.js";
+import {
+  CLAWBITS_SERVICE_HANDOFF_CAPABILITY,
+  registerSlimChannelHandoff,
+} from "../src/service-handoff.js";
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(new URL(path, import.meta.url), "utf8")) as Record<string, unknown>;
+}
+
+function compareVersions(a: string, b: string): number {
+  const left = a.split(".").map(Number);
+  const right = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+const DEFAULT_ACCOUNT = {
+  endpoint: "https://app.clawbits.test",
+  orgId: "org-1",
+  agentId: "agent-1",
+  apiKey: "secret-key",
+  channelId: "channel-1",
+  knownAnswers: { "What is the capital of France?": "Paris" },
+};
+
+interface RegisteredTool {
+  tool: StubAgentTool;
+  optional: boolean;
+}
+
+function runtimeWithHandoff(version?: string): OpenClawPluginApi["runtime"] {
+  const contexts = new Map<string, unknown>();
+  const runtime: OpenClawPluginApi["runtime"] = {
+    version: "2026.6.33",
+    channel: {
+      runtimeContexts: {
+        register({ channelId, capability, context }: {
+          channelId: string;
+          capability: string;
+          context: unknown;
+        }) {
+          const key = `${channelId}:${capability}`;
+          contexts.set(key, context);
+          return { dispose: () => contexts.delete(key) };
+        },
+        get<T>({ channelId, capability }: {
+          channelId: string;
+          capability: string;
+        }): T | undefined {
+          return contexts.get(`${channelId}:${capability}`) as T | undefined;
+        },
+      },
+    },
+  };
+  if (version) registerSlimChannelHandoff(runtime, version);
+  return runtime;
+}
+
+function pluginApi(
+  section: Record<string, unknown>,
+  opts: { registrationMode?: string; runtime?: OpenClawPluginApi["runtime"] } = {},
+): {
+  api: OpenClawPluginApi;
+  tools: RegisteredTool[];
+  hooks: string[];
+  handlers: Map<string, Array<(...args: any[]) => unknown>>;
+} {
+  const tools: RegisteredTool[] = [];
+  const hooks: string[] = [];
+  const handlers = new Map<string, Array<(...args: any[]) => unknown>>();
+  const api: OpenClawPluginApi = {
+    registrationMode: opts.registrationMode ?? "tool-discovery",
+    config: { channels: { clawbits: section } },
+    logger: {},
+    runtime: opts.runtime ?? runtimeWithHandoff(),
+    registerTool(tool, registration) {
+      tools.push({ tool, optional: registration?.optional === true });
+    },
+    on(hook, handler) {
+      hooks.push(hook);
+      const existing = handlers.get(hook) ?? [];
+      existing.push(handler);
+      handlers.set(hook, existing);
+    },
+  };
+  return { api, tools, hooks, handlers };
+}
+
+function configuredApi(): ReturnType<typeof pluginApi> {
+  return pluginApi({ accounts: { default: { ...DEFAULT_ACCOUNT } } });
+}
+
+function registeredTools(api = configuredApi().api): RegisteredTool[] {
+  const collected: RegisteredTool[] = [];
+  const original = api.registerTool.bind(api);
+  api.registerTool = ((tool: StubAgentTool, opts?: { optional?: boolean }) => {
+    collected.push({ tool, optional: opts?.optional === true });
+    original(tool, opts);
+  }) as OpenClawPluginApi["registerTool"];
+  toolsEntry.register(api);
+  return collected;
+}
+
+function findTool(name: (typeof CLAWBITS_TOOL_NAMES)[number]): StubAgentTool {
+  const tool = registeredTools().find((candidate) => candidate.tool.name === name)?.tool;
+  assert.ok(tool, `tool ${name}`);
+  return tool;
+}
+
+async function executeTool(
+  tool: StubAgentTool,
+  params: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const result = (await tool.execute("tool-call-1", params, signal)) as {
+    details?: unknown;
+  };
+  return result.details;
+}
+
+async function callWithMockedFetch(
+  tool: StubAgentTool,
+  params: Record<string, unknown>,
+  respond: (input: unknown, init?: RequestInit) => Response,
+): Promise<{ result: unknown; init: RequestInit | undefined }> {
+  const originalFetch = globalThis.fetch;
+  let seenInit: RequestInit | undefined;
+  try {
+    globalThis.fetch = async (input, init) => {
+      seenInit = init;
+      return respond(input, init);
+    };
+    return { result: await executeTool(tool, params), init: seenInit };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe("clawbits companion plugin", () => {
+  it("registers stable optional tools matching cold manifest metadata", () => {
+    const registrations = registeredTools();
+    assert.equal(toolsEntry.id, "clawbits-tools");
+    assert.deepEqual(
+      registrations.map(({ tool }) => tool.name),
+      [...CLAWBITS_TOOL_NAMES],
+    );
+    assert.ok(registrations.every(({ optional }) => optional));
+
+    const manifest = readJson("../openclaw.tools.plugin.json") as {
+      requiresPlugins?: string[];
+      skills?: string[];
+      contracts?: { tools?: string[] };
+      toolMetadata?: Record<string, { optional?: boolean }>;
+    };
+    assert.deepEqual(manifest.requiresPlugins, ["clawbits"]);
+    assert.deepEqual(manifest.skills, ["./skills"]);
+    assert.deepEqual(manifest.contracts?.tools, [...CLAWBITS_TOOL_NAMES]);
+    assert.deepEqual(Object.keys(manifest.toolMetadata ?? {}), [...CLAWBITS_TOOL_NAMES]);
+    assert.ok(Object.values(manifest.toolMetadata ?? {}).every((tool) => tool.optional === true));
+  });
+
+  it("publishes a separate mixed tools/services entry", () => {
+    const pkg = readJson("../package.tools.json") as {
+      name?: string;
+      version?: string;
+      dependencies?: Record<string, string>;
+      openclaw?: {
+        id?: string;
+        extensions?: string[];
+        runtimeExtensions?: string[];
+        skills?: string[];
+      };
+    };
+    const channelPkg = readJson("../package.json") as { version?: string };
+    assert.equal(pkg.name, "clawbits-openclaw-tools");
+    assert.equal(
+      pkg.version?.split(".").slice(0, 2).join("."),
+      channelPkg.version?.split(".").slice(0, 2).join("."),
+    );
+    assert.equal(pkg.openclaw?.id, "clawbits-tools");
+    assert.deepEqual(pkg.openclaw?.extensions, ["./dist/tools-entry.js"]);
+    assert.deepEqual(pkg.openclaw?.runtimeExtensions, ["./dist/tools-entry.js"]);
+    assert.deepEqual(pkg.openclaw?.skills, ["./skills"]);
+    assert.ok(pkg.dependencies?.["typebox"]);
+  });
+
+  it("declares one consistent OpenClaw compatibility floor", () => {
+    const pkg = readJson("../package.tools.json") as {
+      peerDependencies?: Record<string, string>;
+      openclaw?: {
+        compat?: { pluginApi?: string; minGatewayVersion?: string };
+        build?: { openclawVersion?: string };
+      };
+    };
+    const floor = pkg.openclaw?.compat?.minGatewayVersion;
+    const build = pkg.openclaw?.build?.openclawVersion;
+    assert.ok(floor);
+    assert.ok(build);
+    assert.equal(pkg.openclaw?.compat?.pluginApi, `>=${floor}`);
+    assert.equal(pkg.peerDependencies?.["openclaw"], `>=${floor}`);
+    assert.ok(compareVersions(floor, build) <= 0);
+  });
+
+  it("pins tools compatibility to Reef's reviewed OpenClaw floor", () => {
+    const expectedFloor = "2026.6.10";
+    const dockerfile = readFileSync(
+      new URL("../../reef/images/openclaw-runtime/Dockerfile", import.meta.url),
+      "utf8",
+    );
+    assert.equal(
+      /^ARG OPENCLAW_VERSION=(\S+)/mu.exec(dockerfile)?.[1],
+      expectedFloor,
+      "review tools compatibility when Reef changes",
+    );
+    const pkg = readJson("../package.tools.json") as {
+      openclaw?: { compat?: { minGatewayVersion?: string } };
+    };
+    assert.equal(pkg.openclaw?.compat?.minGatewayVersion, expectedFloor);
+  });
+
+  it("registers services only in full runtime mode", () => {
+    const discovery = pluginApi({}, { registrationMode: "tool-discovery" });
+    toolsEntry.register(discovery.api);
+    assert.deepEqual(discovery.hooks, []);
+
+    const full = pluginApi({}, { registrationMode: "full" });
+    toolsEntry.register(full.api);
+    assert.ok(full.hooks.includes("gateway_start"));
+    assert.ok(full.hooks.includes("gateway_stop"));
+    assert.ok(full.hooks.includes("cron_changed"));
+  });
+
+  it("starts and stops the owner-gated lifecycle idempotently", async () => {
+    const setup = pluginApi(
+      { serviceOwner: "tools" },
+      { registrationMode: "full", runtime: runtimeWithHandoff("0.17.0") },
+    );
+    toolsEntry.register(setup.api);
+    const start = setup.handlers.get("gateway_start")?.[0];
+    const stop = setup.handlers.get("gateway_stop")?.[0];
+    assert.ok(start);
+    assert.ok(stop);
+    await start({}, { config: setup.api.config });
+    await start({}, { config: setup.api.config });
+    await stop();
+    await stop();
+  });
+
+  it("fails closed until tools ownership and a compatible slim channel marker agree", () => {
+    const channelOwned = pluginApi({ serviceOwner: "channel" });
+    assert.deepEqual(resolveCompanionServiceActivation(channelOwned.api.config, channelOwned.api.runtime), {
+      active: false,
+      reason: "channel-owner",
+    });
+
+    const noMarker = pluginApi(
+      { serviceOwner: "tools" },
+      { runtime: runtimeWithHandoff() },
+    );
+    assert.equal(
+      resolveCompanionServiceActivation(noMarker.api.config, noMarker.api.runtime).reason,
+      "missing-slim-channel",
+    );
+
+    const oldChannel = pluginApi(
+      { serviceOwner: "tools" },
+      { runtime: runtimeWithHandoff("0.16.99") },
+    );
+    assert.equal(
+      resolveCompanionServiceActivation(oldChannel.api.config, oldChannel.api.runtime).reason,
+      "missing-slim-channel",
+    );
+
+    const malformed = pluginApi(
+      { serviceOwner: "tools" },
+      { runtime: runtimeWithHandoff("not-a-version") },
+    );
+    assert.equal(
+      resolveCompanionServiceActivation(malformed.api.config, malformed.api.runtime).reason,
+      "missing-slim-channel",
+    );
+
+    const ready = pluginApi(
+      { serviceOwner: "tools" },
+      { runtime: runtimeWithHandoff("0.17.0") },
+    );
+    assert.deepEqual(resolveCompanionServiceActivation(ready.api.config, ready.api.runtime), {
+      active: true,
+      reason: "active",
+    });
+
+    const invalid = pluginApi({ serviceOwner: "somewhere" });
+    assert.equal(
+      resolveCompanionServiceActivation(invalid.api.config, invalid.api.runtime).reason,
+      "invalid-owner",
+    );
+  });
+
+  it("uses channel account config without exposing its API key", async () => {
+    const listTool = findTool("clawbits_channels_list");
+    let authorization = "";
+    const { result, init } = await callWithMockedFetch(listTool, {}, (_input, requestInit) => {
+      authorization = new Headers(requestInit?.headers).get("Authorization") ?? "";
+      return new Response(JSON.stringify([{ channel_id: "channel-1" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    assert.deepEqual(result, [{ channel_id: "channel-1" }]);
+    assert.equal(authorization, "Bearer secret-key");
+    assert.ok(!JSON.stringify(result).includes("secret-key"));
+    assert.ok(init?.signal instanceof AbortSignal);
+  });
+
+  it("fails clearly when the channel account is missing", async () => {
+    const setup = pluginApi({});
+    const tools = registeredTools(setup.api);
+    const info = tools.find(({ tool }) => tool.name === "clawbits_agent_info")?.tool;
+    assert.ok(info);
+    await assert.rejects(() => executeTool(info, {}), /channel plugin first/);
+  });
+
+  it("rejects an unknown account id instead of falling back", async () => {
+    const setup = pluginApi({
+      ...DEFAULT_ACCOUNT,
+      accounts: { work: { ...DEFAULT_ACCOUNT, agentId: "agent-work" } },
+    });
+    const info = registeredTools(setup.api).find(
+      ({ tool }) => tool.name === "clawbits_agent_info",
+    )?.tool;
+    assert.ok(info);
+    await assert.rejects(() => executeTool(info, { accountId: "wrok" }), /Unknown Clawbits account/);
+  });
+
+  it("honors account and email kill switches", async () => {
+    const disabled = pluginApi({ accounts: { default: { ...DEFAULT_ACCOUNT, enabled: false } } });
+    const list = registeredTools(disabled.api).find(
+      ({ tool }) => tool.name === "clawbits_channels_list",
+    )?.tool;
+    assert.ok(list);
+    await assert.rejects(() => executeTool(list, {}), /disabled/);
+
+    const noEmail = pluginApi({
+      accounts: { default: { ...DEFAULT_ACCOUNT, emailEnabled: false } },
+    });
+    for (const name of ["clawbits_email_inbox", "clawbits_email_get", "clawbits_email_send"] as const) {
+      const tool = registeredTools(noEmail.api).find(({ tool }) => tool.name === name)?.tool;
+      assert.ok(tool);
+      const params = name === "clawbits_email_get"
+        ? { messageUid: 1 }
+        : name === "clawbits_email_send"
+          ? { subject: "x", message: "y" }
+          : {};
+      await assert.rejects(() => executeTool(tool, params), /email integration is disabled/);
+    }
+  });
+
+  it("sends owner email through the companion tool", async () => {
+    const send = findTool("clawbits_email_send");
+    let body: unknown;
+    const { result } = await callWithMockedFetch(
+      send,
+      { subject: "Status", message: "Done" },
+      (input, init) => {
+        const target = String(input);
+        if (target.endsWith("/api/agentic/auth/challenge")) {
+          return new Response(
+            JSON.stringify({
+              session_token: "session-1",
+              challenge: "What is the capital of France?",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (target.endsWith("/api/agentic/agents/agent-1/email/send")) {
+          body = JSON.parse(String(init?.body));
+          return new Response(JSON.stringify({ status: "sent", subject: "Status" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (target.endsWith("/api/agentic/mm/channels/channel-1/posts")) {
+          return new Response(JSON.stringify({ post_id: "mirror-1" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(`unexpected: ${target}`, { status: 500 });
+      },
+    );
+    assert.deepEqual(body, { subject: "Status", message: "Done" });
+    assert.match(JSON.stringify(result), /Status/);
+  });
+
+  it("updates the agent description through the companion tool", async () => {
+    const update = findTool("clawbits_agent_description_update");
+    let body: unknown;
+    const { result } = await callWithMockedFetch(
+      update,
+      { description: "Research helper" },
+      (input, init) => {
+        const target = String(input);
+        if (target.endsWith("/api/agentic/auth/challenge")) {
+          return new Response(
+            JSON.stringify({
+              session_token: "session-1",
+              challenge: "What is the capital of France?",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        assert.ok(target.endsWith("/api/agentic/agents/agent-1/description"));
+        body = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ agent_id: "agent-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+    assert.deepEqual(body, { description: "Research helper" });
+    assert.deepEqual(result, { agent_id: "agent-1" });
+  });
+
+  it("rejects blank write-tool payloads", async () => {
+    await assert.rejects(
+      () => executeTool(findTool("clawbits_email_send"), { subject: " ", message: "x" }),
+      /must not be blank/,
+    );
+    await assert.rejects(
+      () => executeTool(findTool("clawbits_agent_description_update"), { description: " " }),
+      /must not be blank/,
+    );
+  });
+
+  it("strips attachment bodies from email reads", async () => {
+    const getTool = findTool("clawbits_email_get");
+    const payload = {
+      uid: 7,
+      subject: "invoice",
+      body_text: "see attached",
+      attachments: [
+        { filename: "big.pdf", content_type: "application/pdf", content_b64: "A".repeat(8000) },
+      ],
+    };
+    const { result } = await callWithMockedFetch(getTool, { messageUid: 7 }, () =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    assert.ok(!JSON.stringify(result).includes("AAAA"));
+    assert.deepEqual((result as { attachments?: unknown }).attachments, [
+      { filename: "big.pdf", content_type: "application/pdf", size: 6000 },
+    ]);
+  });
+
+  it("refuses an already-aborted tool call", async () => {
+    const listTool = findTool("clawbits_channels_list");
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+    await assert.rejects(() => executeTool(listTool, {}, controller.signal));
+  });
+
+  it("keeps the channel entry free of moved service registrations", () => {
+    const index = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+    const gateway = readFileSync(new URL("../src/gateway-adapter.ts", import.meta.url), "utf8");
+    const actions = readFileSync(new URL("../src/channel-actions.ts", import.meta.url), "utf8");
+    for (const forbidden of [
+      "runAutomationsReconciler",
+      "runEmailPoller",
+      "runUsageReporter",
+      "runSkillsReporter",
+      "registerUsageHooks",
+    ]) {
+      assert.ok(!index.includes(forbidden), `${forbidden} absent from channel entry`);
+      assert.ok(!gateway.includes(forbidden), `${forbidden} absent from channel gateway`);
+    }
+    assert.ok(!actions.includes("send_email"));
+    assert.ok(!actions.includes("update_description"));
+
+    const pkg = readJson("../package.json") as {
+      files?: string[];
+      openclaw?: { extensions?: string[]; skills?: string[] };
+    };
+    assert.ok(!pkg.files?.includes("src"));
+    assert.ok(!pkg.files?.includes("skills"));
+    assert.deepEqual(pkg.openclaw?.extensions, ["./dist/index.js"]);
+    assert.equal(pkg.openclaw?.skills, undefined);
+
+    const manifest = readJson("../openclaw.plugin.json") as {
+      skills?: string[];
+      channelConfigs?: {
+        clawbits?: {
+          schema?: {
+            properties?: Record<string, { enum?: string[]; default?: string }>;
+          };
+        };
+      };
+    };
+    assert.equal(manifest.skills, undefined);
+    assert.deepEqual(
+      manifest.channelConfigs?.clawbits?.schema?.properties?.serviceOwner,
+      {
+        type: "string",
+        enum: ["channel", "tools"],
+        default: "channel",
+        description:
+          "Owner of Clawbits cron, email, usage, and skills services. Set to tools only after installing a compatible clawbits-tools plugin.",
+      },
+    );
+  });
+
+  it("uses the stable handoff capability name", () => {
+    assert.equal(CLAWBITS_SERVICE_HANDOFF_CAPABILITY, "service-handoff");
+  });
+});

--- a/plugin/tsconfig.test.json
+++ b/plugin/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  // Typecheck-only superset of tsconfig.json that also covers the tools
+  // entry's contract test. `bun test` strips types without checking and the
+  // build config's include is src-only, so without this the one file pinning
+  // the SDK contract shape would never be typechecked anywhere.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test/tools-entry.test.ts"]
+}


### PR DESCRIPTION
## What and why  
   Splits the Clawbits OpenClaw integration into a strict channel package and an independently installable tools/services companion. Cron, email, usage, skills, and optional agent tools move to the companion while ownership gating prevents duplicate workers and
 preserves existing configuration and state.

   ## How to verify

  ```sh
   cd plugin
   bun install --frozen-lockfile
   bun run typecheck
   bun test
   bun run build

   tmp="$(mktemp -d)"
   node stage-channel.mjs "$tmp/channel"
   node stage-tools.mjs "$tmp/tools"

   (cd "$tmp/channel" && npm pack --dry-run)
   (cd "$tmp/tools" && npm pack --dry-run)

   rm -rf "$tmp"
```

   Expected:

   - 397 tests pass.
   - Channel artifact excludes companion services, tools, and skills.
   - Companion artifact excludes channel entry, gateway, CLI, and channel actions.
   - CI validates both artifacts against OpenClaw `2026.6.10` and `2026.6.33`.

   ## Notes

   - Credentials remain under `channels.clawbits.*`; signup is not repeated.
   - Missing `serviceOwner` defaults to `channel`.
   - Companion services start only with `serviceOwner=tools` and a compatible slim-channel marker.
   - Existing pinned versions continue working unchanged.
   - Publishing is ordered: companion first, matching channel second.
   - Reef and onboarding changes are deliberately deferred until both packages are published and verified.
   - Current commits need conventional subjects and `Signed-off-by` trailers before merge.

   ---

   - [ ] Commits signed off (`git commit -s`) — see [CONTRIBUTING](CONTRIBUTING.md#sign-off-dco)
   - [ ] Conventional commit subject (`feat:` / `fix:` / `chore:` …) — this decides the version bump
   - [x] Tests added or updated for behaviour changes
   - [x] `db_schema.md` regenerated if a model changed, and a migration added — not applicable; no model changes
