### PR TITLE
Fix cross-tenant data exposure across five list routes, post interactions, channel membership and org removal

### DIFF
--- a/clawbits/db/table_read.py
+++ b/clawbits/db/table_read.py
@@ -446,10 +446,21 @@ class TableRead:
 
     @staticmethod
     def get_recent_shared_content(
-        session: Session, limit: int = 50, offset: int = 0
+        session: Session, org_ids: list[str], limit: int = 50, offset: int = 0
     ) -> list[dict]:
+        """Recent shared files, restricted to agents in ``org_ids``.
+
+        ``org_ids`` is required, not optional: this feed used to select every
+        row in the table, so a caller that forgets to scope it is the bug.
+        The join also excludes the cross-org ``deleted-agent`` placeholder,
+        which has no org by construction.
+        """
+        if not org_ids:
+            return []
         rows = session.exec(
             select(ShareRecord)
+            .join(Agent, Agent.agent_id == ShareRecord.agent_id)
+            .where(Agent.org_id.in_(org_ids))
             .where(ShareRecord.deleted_at.is_(None))
             .order_by(ShareRecord.timestamp.desc())
             .limit(limit)
@@ -577,13 +588,22 @@ class TableRead:
     @staticmethod
     def get_all_agent_posts(
         session: Session,
+        org_ids: list[str],
         limit: int = 50,
         offset: int = 0,
         current_human_id: int | None = None,
         current_agent_id: str | None = None,
     ) -> list[dict]:
+        """Recent agent posts, restricted to agents in ``org_ids``.
+
+        See :meth:`get_recent_shared_content` for why the scope is required.
+        """
+        if not org_ids:
+            return []
         rows = session.exec(
             select(AgentPost)
+            .join(Agent, Agent.agent_id == AgentPost.agent_id)
+            .where(Agent.org_id.in_(org_ids))
             .order_by(AgentPost.timestamp.desc())
             .limit(limit)
             .offset(offset)
@@ -1382,6 +1402,20 @@ class TableRead:
                 tokens.add(handle)
         alternation = "|".join(re.escape(t) for t in sorted(tokens) if t)
         return rf"@({alternation})([^a-z0-9_.-]|$)"
+
+    @staticmethod
+    def get_org_ids_for_human(session: Session, human_id: int) -> list[str]:
+        """Org ids this human belongs to.
+
+        Deliberately minimal: the org-scoped read paths only need the ids, and
+        ``get_orgs_for_human`` computes per-org unread aggregates that would be
+        pure waste on those routes.
+        """
+        return list(
+            session.exec(
+                select(OrgMember.org_id).where(OrgMember.human_id == human_id)
+            ).all()
+        )
 
     @staticmethod
     def is_org_member(session: Session, org_id: str, human_id: int) -> bool:
@@ -3424,10 +3458,18 @@ class TableRead:
 
     @staticmethod
     def list_agent_actions(
-        session: Session, limit: int = 100, offset: int = 0
+        session: Session, org_ids: list[str], limit: int = 100, offset: int = 0
     ) -> list[dict]:
+        """Action-document metadata, restricted to agents in ``org_ids``.
+
+        See :meth:`get_recent_shared_content` for why the scope is required.
+        """
+        if not org_ids:
+            return []
         rows = session.exec(
             select(AgentAction)
+            .join(Agent, Agent.agent_id == AgentAction.agent_id)
+            .where(Agent.org_id.in_(org_ids))
             .order_by(AgentAction.updated_at.desc())
             .limit(limit)
             .offset(offset)
@@ -3442,8 +3484,20 @@ class TableRead:
         ]
 
     @staticmethod
-    def count_agent_actions(session: Session) -> int:
-        count = session.exec(select(func.count()).select_from(AgentAction)).one()
+    def count_agent_actions(session: Session, org_ids: list[str]) -> int:
+        """Total actions visible to ``org_ids``.
+
+        Must match :meth:`list_agent_actions`' scope, or pagination reports
+        rows the caller cannot read.
+        """
+        if not org_ids:
+            return 0
+        count = session.exec(
+            select(func.count())
+            .select_from(AgentAction)
+            .join(Agent, Agent.agent_id == AgentAction.agent_id)
+            .where(Agent.org_id.in_(org_ids))
+        ).one()
         return int(count or 0)
 
     @staticmethod

--- a/clawbits/db/table_write.py
+++ b/clawbits/db/table_write.py
@@ -1815,13 +1815,54 @@ class TableWrite:
         session.flush()
 
     @staticmethod
-    def remove_org_member(session: Session, org_id: str, human_id: int) -> None:
+    def remove_org_member(session: Session, org_id: str, human_id: int) -> list[str]:
+        """Remove a human from an org, and from that org's channels.
+
+        Dropping only the ``OrgMember`` row left every ``mm_channel_members``
+        row intact, so an ex-member kept full access: channel reads and writes
+        still passed ``_require_human_member`` (which asks about *channel*
+        membership, not org membership), and open SSE streams passed their
+        periodic re-check forever. Deleting the channel rows is what actually
+        revokes access, and it makes every existing gate answer correctly
+        rather than requiring a new org check on every route.
+
+        Channels are deliberately **not** torn down when this empties them of
+        humans: the org still owns them, and an owner can delete them from
+        Settings. A now-human-less DM is likewise left in place - if the
+        person rejoins, ``_reopen_orphaned_dm`` heals it rather than colliding.
+
+        Returns the channel ids the human was removed from, so the caller can
+        close their live streams and drop the channels from their sidebar.
+        """
+        channel_ids = list(
+            session.exec(
+                select(MmChannelMember.channel_id)
+                .join(MmChannel, MmChannel.channel_id == MmChannelMember.channel_id)
+                .where(MmChannelMember.human_id == human_id)
+                .where(MmChannel.org_id == org_id)
+            ).all()
+        )
+        if channel_ids:
+            session.exec(
+                delete(MmChannelMember)
+                .where(MmChannelMember.human_id == human_id)
+                .where(MmChannelMember.channel_id.in_(channel_ids))
+            )
+            # Their own per-channel UI state (read pointer, mute, pin) goes with
+            # it. Scoped to this human: other members' pointers must not be
+            # touched.
+            session.exec(
+                delete(HumanChannelState)
+                .where(HumanChannelState.human_id == human_id)
+                .where(HumanChannelState.channel_id.in_(channel_ids))
+            )
         session.exec(
             delete(OrgMember)
             .where(OrgMember.org_id == org_id)
             .where(OrgMember.human_id == human_id)
         )
         session.flush()
+        return channel_ids
 
     @staticmethod
     def update_org_member_role(

--- a/clawbits/fastapi/clawbits_server.py
+++ b/clawbits/fastapi/clawbits_server.py
@@ -2225,7 +2225,16 @@ class ClawBitsServer(FastAPI):
                     raise HTTPException(status_code=401, detail="Invalid API key")
 
             with Session(self._engine) as db:
-                posts = TableRead.get_all_agent_posts(db, limit=limit, offset=offset)
+                # An agent sees its own org's posts, not the deployment's.
+                agent_org_id = TableRead.get_agent_org_id(db, str(user.agent_id))
+                org_ids = [agent_org_id] if agent_org_id else []
+                posts = TableRead.get_all_agent_posts(
+                    db,
+                    org_ids,
+                    limit=limit,
+                    offset=offset,
+                    current_agent_id=str(user.agent_id),
+                )
 
             return {"posts": posts, "total": len(posts)}
 
@@ -4498,8 +4507,13 @@ class ClawBitsServer(FastAPI):
             agent = TableRead.get_agent_by_api_key(db, token)
             if agent is None:
                 raise HTTPException(status_code=401, detail="Invalid API key")
-            items = TableRead.list_agent_actions(db, limit=limit, offset=offset)
-            total = TableRead.count_agent_actions(db)
+            # An agent sees the registry of its own org, not the deployment's.
+            # ``get_agent_by_api_key`` returns the datastructures Agent, which
+            # carries no org - resolve it from the row.
+            agent_org_id = TableRead.get_agent_org_id(db, str(agent.agent_id))
+            org_ids = [agent_org_id] if agent_org_id else []
+            items = TableRead.list_agent_actions(db, org_ids, limit=limit, offset=offset)
+            total = TableRead.count_agent_actions(db, org_ids)
 
         return ActionListResponse(
             actions=[ActionListItem(**i) for i in items],

--- a/clawbits/fastapi/contact_permissions_endpoints.py
+++ b/clawbits/fastapi/contact_permissions_endpoints.py
@@ -164,6 +164,19 @@ def set_contact_permission(
                     status_code=404,
                     detail=f"Agent '{body.principal_id}' not found",
                 )
+            # Same org boundary the human branch above enforces. Without it
+            # an operator could grant an agent from any org DM/tag rights on
+            # their own, opening a cross-tenant agent-to-agent channel.
+            # ``is_agent_in_org`` rather than comparing org ids by hand, so the
+            # cross-org ``deleted-agent`` placeholder can never satisfy it.
+            agent_org_id = TableRead.get_agent_org_id(db, agent_id)
+            if agent_org_id is None or not TableRead.is_agent_in_org(
+                db, body.principal_id, agent_org_id
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Principal must belong to the agent's organization",
+                )
             TableWrite.upsert_agent_contact_permission(
                 db,
                 agent_id,

--- a/clawbits/fastapi/human_endpoints.py
+++ b/clawbits/fastapi/human_endpoints.py
@@ -96,6 +96,8 @@ from clawbits.realtime import (
     get_bus,
     publish_automation_sync,
     publish_channel_event,
+    publish_channel_removed,
+    publish_member_removed,
     publish_org_added,
     publish_org_updated,
 )
@@ -353,6 +355,26 @@ def _verify_agent_in_org(db, org_id: str, agent_id: str) -> None:
     """Verify the agent is associated with the given organization."""
     if not TableRead.is_agent_in_org(db, agent_id, org_id):
         raise HTTPException(status_code=404, detail="Agent not found in this organization")
+
+
+def _require_visible_post(db, post_id: int, user: dict) -> None:
+    """404 unless ``post_id`` belongs to an agent in one of the caller's orgs.
+
+    ``agent_posts.post_id`` is a bare serial, so these routes were trivially
+    enumerable across tenants. 404 rather than 403 is deliberate: a 403 would
+    confirm that a given id exists in somebody else's organization.
+
+    An agent with no org (unapproved, or the shared ``deleted-agent``
+    placeholder) is visible to nobody, matching ``is_agent_in_org``.
+    """
+    from clawbits.db.models import AgentPost
+
+    post = db.get(AgentPost, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    org_id = TableRead.get_agent_org_id(db, post.agent_id)
+    if org_id is None or not TableRead.is_org_member(db, org_id, user["id"]):
+        raise HTTPException(status_code=404, detail="Post not found")
 
 
 def _require_agent_operator(db, agent_id: str, user: dict) -> None:
@@ -1611,9 +1633,12 @@ async def list_shared_content(
     offset: int = 0,
     user: dict = Depends(get_current_human_user),
 ):
-    """List recent shared files for the dashboard feed."""
+    """List recent shared files across the caller's organizations."""
     with _get_db(request) as db:
-        files = TableRead.get_recent_shared_content(db, limit=limit, offset=offset)
+        org_ids = TableRead.get_org_ids_for_human(db, user["id"])
+        files = TableRead.get_recent_shared_content(
+            db, org_ids, limit=limit, offset=offset
+        )
         return {"files": files, "total": len(files), "limit": limit, "offset": offset}
 
 
@@ -1624,9 +1649,12 @@ async def list_all_agent_posts(
     offset: int = 0,
     user: dict = Depends(get_current_human_user),
 ):
-    """List recent posts from all agents for the dashboard feed."""
+    """List recent agent posts across the caller's organizations."""
     with _get_db(request) as db:
-        posts = TableRead.get_all_agent_posts(db, limit=limit, offset=offset, current_human_id=user["id"])
+        org_ids = TableRead.get_org_ids_for_human(db, user["id"])
+        posts = TableRead.get_all_agent_posts(
+            db, org_ids, limit=limit, offset=offset, current_human_id=user["id"]
+        )
         return {"posts": posts, "total": len(posts), "limit": limit, "offset": offset}
 
 
@@ -1658,12 +1686,9 @@ async def like_post(
     request: Request,
     user: dict = Depends(get_current_human_user),
 ):
-    """Like a post."""
-    from clawbits.db.models import AgentPost
-
+    """Like a post in one of the caller's organizations."""
     with _get_db(request) as db:
-        if db.get(AgentPost, post_id) is None:
-            raise HTTPException(status_code=404, detail="Post not found")
+        _require_visible_post(db, post_id, user)
         TableWrite.create_post_like(db, post_id, human_id=user["id"])
         db.commit()
     return {"status": "ok"}
@@ -1674,8 +1699,9 @@ async def unlike_post(
     request: Request,
     user: dict = Depends(get_current_human_user),
 ):
-    """Remove like from a post."""
+    """Remove like from a post in one of the caller's organizations."""
     with _get_db(request) as db:
+        _require_visible_post(db, post_id, user)
         TableWrite.delete_post_like(db, post_id, human_id=user["id"])
         db.commit()
     return {"status": "ok"}
@@ -1688,12 +1714,13 @@ async def get_post_comments(
     offset: int = 0,
     user: dict = Depends(get_current_human_user),
 ):
-    """Get comments for a post."""
-    from clawbits.db.models import AgentPost
+    """Get comments for a post in one of the caller's organizations.
 
+    The rows carry each commenter's display name and email, so an unscoped
+    read here leaked personal data, not just post content.
+    """
     with _get_db(request) as db:
-        if db.get(AgentPost, post_id) is None:
-            raise HTTPException(status_code=404, detail="Post not found")
+        _require_visible_post(db, post_id, user)
         comments = TableRead.get_post_comments(db, post_id, limit, offset)
     return {"comments": comments}
 
@@ -1704,12 +1731,9 @@ async def add_post_comment(
     request: Request,
     user: dict = Depends(get_current_human_user),
 ):
-    """Add a comment to a post."""
-    from clawbits.db.models import AgentPost
-
+    """Add a comment to a post in one of the caller's organizations."""
     with _get_db(request) as db:
-        if db.get(AgentPost, post_id) is None:
-            raise HTTPException(status_code=404, detail="Post not found")
+        _require_visible_post(db, post_id, user)
         comment_id = TableWrite.create_post_comment(
             db, post_id, message=payload.message, human_id=user["id"]
         )
@@ -2396,10 +2420,20 @@ async def remove_org_member(
             if owner_count <= 1:
                 raise HTTPException(status_code=400, detail="Cannot remove the last admin of an organization")
         target = TableRead.get_human_user_by_id(db, member_id)
-        TableWrite.remove_org_member(db, org_id, member_id)
+        # Also drops their membership of this org's channels - that, not the
+        # OrgMember row, is what the per-channel gates actually check.
+        revoked_channel_ids = TableWrite.remove_org_member(db, org_id, member_id)
         org = TableRead.get_organization(db, org_id)
         members = TableRead.get_org_members(db, org_id)
         db.commit()
+
+    bus = get_bus()
+    for channel_id in revoked_channel_ids:
+        # On the channel topic: closes any stream they still have open, rather
+        # than leaving it live until its next periodic re-check.
+        fire_and_forget(publish_member_removed(bus, channel_id, human_id=member_id))
+        # On their personal topic: drops the channel from their sidebar.
+        fire_and_forget(publish_channel_removed(bus, member_id, channel_id))
 
     if org is not None and target is not None:
         from clawbits.fastapi.workos_auth import unregister_membership
@@ -2473,10 +2507,11 @@ async def list_agent_actions(
     offset: int = 0,
     user: dict = Depends(get_current_human_user),
 ):
-    """List all action documents across all agents (metadata only)."""
+    """List action documents for agents in the caller's organizations (metadata only)."""
     with _get_db(request) as db:
-        items = TableRead.list_agent_actions(db, limit=limit, offset=offset)
-        total = TableRead.count_agent_actions(db)
+        org_ids = TableRead.get_org_ids_for_human(db, user["id"])
+        items = TableRead.list_agent_actions(db, org_ids, limit=limit, offset=offset)
+        total = TableRead.count_agent_actions(db, org_ids)
         return ActionListResponse(
             actions=[ActionListItem(**i) for i in items],
             total=total,

--- a/clawbits/fastapi/human_mm_endpoints.py
+++ b/clawbits/fastapi/human_mm_endpoints.py
@@ -898,6 +898,29 @@ async def add_member(
 # DELETE /api/human/mm/channels/{channel_id}/members/{member_id}
 # ---------------------------------------------------------------------------
 
+def _require_channel_admin(db, channel: dict, user: dict) -> None:
+    """Assert the caller may act on other people's membership in ``channel``.
+
+    The channel's **creator** (so you can administer a channel you started)
+    or an **organization owner** (so owners can moderate from Settings).
+    Same predicate ``admin_delete_channel`` uses - removing someone else and
+    deleting the channel outright are the same authority, and this used to be
+    enforced on delete only.
+    """
+    org_id = channel.get("org_id")
+    if org_id is None:
+        raise HTTPException(
+            status_code=400, detail="Channel is not scoped to an organization"
+        )
+    if channel.get("created_by_human") == user["id"]:
+        return
+    if TableRead.get_org_member_role(db, org_id, user["id"]) != "owner":
+        raise HTTPException(
+            status_code=403,
+            detail="Only the channel creator or an organization admin can remove other members",
+        )
+
+
 @human_mm_router.delete("/api/human/mm/channels/{channel_id}/members/{member_id}", response_model=MmChannelMembersListResponse)
 async def remove_member(
     channel_id: str,
@@ -906,7 +929,22 @@ async def remove_member(
     member_type: str = "agent",
     user: dict = Depends(get_current_human_user),
 ):
-    """Remove a member from a channel. Use ?member_type=human for human members. Caller must be a member.
+    """Remove a member from a channel. Use ?member_type=human for human members.
+
+    Two distinct authorities, which used to be one:
+
+    * **Leaving** - removing *yourself* - needs only membership.
+    * **Removing somebody else** needs the channel creator or an org owner,
+      the same predicate that gates deleting the channel. Without it any
+      member could evict every other human one at a time (each removal leaves
+      them the sole human, so the teardown below never fires early), then
+      leave - destroying the channel and its whole history for everyone, and
+      bypassing the creator/owner gate on DELETE /channels/{id}.
+
+    A ``direct`` channel is a two-party conversation, not a group: you may
+    close your own (which tears it down once no humans remain) but you may
+    never remove the other party. Mirrors ``add_member``, which refuses to
+    widen a DM.
 
     When the removal leaves the channel with no human members — i.e. the
     last human leaves a human↔agent DM or a group channel — the channel
@@ -915,6 +953,19 @@ async def remove_member(
     """
     with _get_db(request) as db:
         _require_human_member(db, channel_id, user["id"])
+        channel = TableRead.get_mm_channel(db, channel_id)
+        if channel is None:
+            raise HTTPException(status_code=404, detail="Channel not found")
+
+        removing_self = member_type == "human" and int(member_id) == user["id"]
+        if not removing_self:
+            if channel.get("channel_type") == "direct":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot remove the other party from a direct message channel",
+                )
+            _require_channel_admin(db, channel, user)
+
         removed_human_id: int | None = None
         removed_agent_id: str | None = None
         if member_type == "human":
@@ -2468,6 +2519,33 @@ async def list_pinned_posts(
 # POST /api/human/mm/direct
 # ---------------------------------------------------------------------------
 
+def _reopen_orphaned_dm(
+    db, org_id: str, dm_name: str, human_ids: list[int], agent_ids: list[str]
+) -> dict | None:
+    """Re-attach the missing parties to a DM row that dropped below two members.
+
+    DM channel names are deterministic per (org, pair) and ``mm_channels`` has
+    a unique ``(org_id, name)``. A DM that lost a member is therefore invisible
+    to the find-by-members lookup (which requires both, and a member count of
+    two) *and* impossible to recreate - the insert collides on the name and
+    500s. That stranded the conversation permanently.
+
+    Healing the existing row is preferred over deleting and recreating it: both
+    parties were always privy to this history, so nothing is disclosed that was
+    not already, and no messages are destroyed. Returns the channel, or None
+    when there is no such row and the caller should create one.
+    """
+    existing = TableRead.get_mm_channel_by_org_and_name(db, org_id, dm_name)
+    if existing is None:
+        return None
+    for hid in human_ids:
+        TableWrite.add_mm_channel_member_human(db, existing["channel_id"], hid)
+    for aid in agent_ids:
+        TableWrite.add_mm_channel_member(db, existing["channel_id"], aid)
+    db.commit()
+    return existing
+
+
 @human_mm_router.post("/api/human/mm/direct", response_model=MmChannelResponse)
 async def create_or_get_direct(
     body: MmDirectUnifiedRequest,
@@ -2507,19 +2585,28 @@ async def create_or_get_direct(
                 TableRead.apply_dm_peer_display(db, [existing], human_id)
                 return MmChannelResponse(**existing)
 
-            channel_id = str(uuid.uuid4())
             sorted_ids = sorted([human_id, target_human_id])
             dm_name = f"dm-human-{sorted_ids[0]}-human-{sorted_ids[1]}"
-            display_a = user.get("display_name") or user.get("email", str(human_id))
-            display_b = target.get("display_name") or target.get("email", str(target_human_id))
-            TableWrite.create_mm_channel(
-                db, channel_id,
-                dm_name, "direct", display_name=f"DM: {display_a} ↔ {display_b}",
-                org_id=org_id,
+            # A prior removal can leave this row with one member: found by name
+            # but not by membership. Re-attach both rather than colliding on
+            # the unique (org_id, name).
+            healed = _reopen_orphaned_dm(
+                db, org_id, dm_name, [human_id, target_human_id], []
             )
-            TableWrite.add_mm_channel_member_human(db, channel_id, human_id)
-            TableWrite.add_mm_channel_member_human(db, channel_id, target_human_id)
-            db.commit()
+            if healed is not None:
+                channel_id = healed["channel_id"]
+            else:
+                channel_id = str(uuid.uuid4())
+                display_a = user.get("display_name") or user.get("email", str(human_id))
+                display_b = target.get("display_name") or target.get("email", str(target_human_id))
+                TableWrite.create_mm_channel(
+                    db, channel_id,
+                    dm_name, "direct", display_name=f"DM: {display_a} ↔ {display_b}",
+                    org_id=org_id,
+                )
+                TableWrite.add_mm_channel_member_human(db, channel_id, human_id)
+                TableWrite.add_mm_channel_member_human(db, channel_id, target_human_id)
+                db.commit()
             notify_human_ids = [human_id, target_human_id]
 
         else:  # target_type == "agent"
@@ -2547,17 +2634,24 @@ async def create_or_get_direct(
                 TableRead.apply_dm_peer_display(db, [existing], human_id)
                 return MmChannelResponse(**existing)
 
-            channel_id = str(uuid.uuid4())
             dm_name = agent_dm_channel_name(human_id, target_agent_id)
-            display_h = user.get("display_name") or user.get("email", str(human_id))
-            TableWrite.create_mm_channel(
-                db, channel_id,
-                dm_name, "direct", display_name=f"DM: {display_h} ↔ {target_agent_id}",
-                org_id=org_id,
+            # Same orphaned-DM heal as the human<->human branch above.
+            healed = _reopen_orphaned_dm(
+                db, org_id, dm_name, [human_id], [target_agent_id]
             )
-            TableWrite.add_mm_channel_member_human(db, channel_id, human_id)
-            TableWrite.add_mm_channel_member(db, channel_id, target_agent_id)
-            db.commit()
+            if healed is not None:
+                channel_id = healed["channel_id"]
+            else:
+                channel_id = str(uuid.uuid4())
+                display_h = user.get("display_name") or user.get("email", str(human_id))
+                TableWrite.create_mm_channel(
+                    db, channel_id,
+                    dm_name, "direct", display_name=f"DM: {display_h} ↔ {target_agent_id}",
+                    org_id=org_id,
+                )
+                TableWrite.add_mm_channel_member_human(db, channel_id, human_id)
+                TableWrite.add_mm_channel_member(db, channel_id, target_agent_id)
+                db.commit()
             notify_human_ids = [human_id]
 
         ch = TableRead.get_mm_channel(db, channel_id)

--- a/tests/fastapi/test_action.py
+++ b/tests/fastapi/test_action.py
@@ -316,8 +316,14 @@ def test_human_get_action(test_client):
 
 
 def test_human_list_actions(test_client):
-    """Human can list all action documents."""
-    human = _register_human(test_client, "lister@test.com")
+    """Human lists the action documents of agents in their own org.
+
+    The human must be the agent's operator: ``/api/human/actions`` is
+    org-scoped, and ``_create_agent`` binds the agent to stan's personal org.
+    Listing as an unrelated human used to work only because the route
+    returned every agent in the deployment.
+    """
+    human = _register_human(test_client, "stan@clawbits.ai")
     agent = _create_agent(test_client)
 
     test_client.put(

--- a/tests/fastapi/test_agent_contact_permissions.py
+++ b/tests/fastapi/test_agent_contact_permissions.py
@@ -726,3 +726,58 @@ def test_deleted_agent_tombstone_does_not_shadow_dm_peer(test_client, _test_engi
         headers=_human_auth(owner_token),
     )
     assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Cross-org contact grants (audit finding T0-07)
+# ---------------------------------------------------------------------------
+#
+# The human branch of ``set_contact_permission`` required the principal to be a
+# member of the agent's org; the agent branch checked only that the principal
+# *existed*. A grant says "you may address this agent" - it must not also be
+# able to say "...from outside the organization", or two operators can open a
+# permanent agent-to-agent channel across the tenant boundary.
+
+
+def test_cannot_grant_contact_to_an_agent_in_another_org(test_client, _test_engine):
+    """The agent branch had no org check at all, unlike its human twin."""
+    owner_a = _register_human(test_client, "xorg-a@test.com")
+    agent_a = _create_agent(test_client, "xorg-a@test.com")
+
+    # A wholly separate tenant: its own owner, its own personal org, own agent.
+    _register_human(test_client, "xorg-b@test.com")
+    agent_b = _create_agent(test_client, "xorg-b@test.com")
+
+    r = _grant(
+        test_client, owner_a["access_token"], agent_a["agent_id"],
+        "agent", agent_b["agent_id"], can_dm=True, can_tag=True,
+    )
+    assert r.status_code == 400, r.text
+    assert "organization" in r.json()["detail"].lower()
+
+
+def test_can_still_grant_contact_within_the_org(test_client, _test_engine):
+    """Guard against the lazy fix: same-org agent grants must keep working."""
+    owner = _register_human(test_client, "sameorg-owner@test.com")
+    agent_a = _create_agent(test_client, "sameorg-owner@test.com")
+    agent_b = _create_agent(test_client, "sameorg-owner@test.com")
+
+    r = _grant(
+        test_client, owner["access_token"], agent_a["agent_id"],
+        "agent", agent_b["agent_id"], can_dm=True,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["can_dm"] is True
+
+
+def test_cross_org_human_grant_is_still_refused(test_client, _test_engine):
+    """The human branch's existing check, pinned so the two stay symmetric."""
+    owner_a = _register_human(test_client, "xorgh-a@test.com")
+    agent_a = _create_agent(test_client, "xorgh-a@test.com")
+    stranger = _register_human(test_client, "xorgh-stranger@test.com")
+
+    r = _grant(
+        test_client, owner_a["access_token"], agent_a["agent_id"],
+        "human", stranger["user"]["id"], can_dm=True,
+    )
+    assert r.status_code == 400, r.text

--- a/tests/fastapi/test_agent_search.py
+++ b/tests/fastapi/test_agent_search.py
@@ -10,6 +10,7 @@ from starlette.testclient import TestClient
 
 from tests.fastapi.test_mattermost import (
     _auth,
+    _create_agent_with_owner,
     _create_owned_agent,
     _grant_agent_contact,
     _write_headers,
@@ -124,7 +125,8 @@ def test_private_context_is_context_plus_public(test_client):
 
 def test_agent_agent_dm_context_is_middle_tier(test_client):
     s = _seed(test_client)
-    other = _create_owned_agent(test_client)
+    # Same org as the seeded agent: contact grants are org-scoped.
+    other = _create_agent_with_owner(test_client, s["agent"]["owner_email"])
     _grant_agent_contact(test_client, other, s["agent"], can_dm=True)
     r = test_client.post(
         "/api/agentic/mm/direct",

--- a/tests/fastapi/test_channel_member_org_scope.py
+++ b/tests/fastapi/test_channel_member_org_scope.py
@@ -221,10 +221,34 @@ def test_same_org_agent_add_still_works(test_client):
 # ---------------------------------------------------------------------------
 
 
+def _seed_cross_org_grant(tc, target_agent: dict, principal_agent: dict) -> None:
+    """Write a cross-org contact grant straight to the DB.
+
+    The management API refuses to create one (audit finding T0-07 added that
+    gate), but rows granted before that fix still exist in deployed databases.
+    Seeding directly is what keeps this test exercising the layer it is about:
+    enforcement at *use*, which must refuse a grant regardless of how it got
+    there. The two guards are deliberately independent.
+    """
+    from sqlmodel import Session
+
+    from clawbits.db.table_write import TableWrite
+
+    with Session(tc.app._engine) as db:
+        TableWrite.upsert_agent_contact_permission(
+            db,
+            target_agent["agent_id"],
+            principal_agent_id=principal_agent["agent_id"],
+            can_dm=False,
+            can_tag=True,
+        )
+        db.commit()
+
+
 def test_agent_endpoint_refuses_cross_org_agent(test_client):
     a1 = _create_agent_with_owner(test_client, "ae-one@test.com")
     a2 = _create_agent_with_owner(test_client, "ae-two@test.com")   # different org
-    _grant_agent_contact(test_client, a2, a1, can_tag=True)
+    _seed_cross_org_grant(test_client, a2, a1)
 
     r = test_client.post(
         "/api/agentic/mm/channels",

--- a/tests/fastapi/test_human_auth_api.py
+++ b/tests/fastapi/test_human_auth_api.py
@@ -31,6 +31,18 @@ def _seed_test_agent(test_client):
     api_key = ApiKey.generate().value
     key_hash = hashlib.sha256(api_key.encode()).hexdigest()
 
+    # The share/post feeds are org-scoped, so the seeded agent needs the org the
+    # tests authenticate into. A raw insert skips the signup approval that
+    # normally binds ``org_id``; without it this agent belongs to no org and is
+    # correctly invisible everywhere.
+    _seed_token = get_token(test_client)
+    _seed_org_id = _get_personal_org_id(test_client, _seed_token)
+    # ``login_human`` sets the session cookie on the shared client. Leaving it
+    # there would silently authenticate every later request in this module -
+    # ``test_unauthorized_access`` asserts a bare GET is 401. Tests that want
+    # auth call ``get_token`` themselves and pass a bearer header.
+    test_client.cookies.clear()
+
     with Session(server._engine) as s:
         s.add(
             Agent(
@@ -39,6 +51,7 @@ def _seed_test_agent(test_client):
                 eth_private_key=to_hex(acct.key),
                 nickname="Testy",
                 long_name="TestAgentLongName",
+                org_id=_seed_org_id,
             )
         )
         s.add(

--- a/tests/fastapi/test_mattermost.py
+++ b/tests/fastapi/test_mattermost.py
@@ -252,7 +252,8 @@ def test_create_and_list_channel(test_client):
 def test_get_channel_info(test_client):
     """Members can get channel info; non-members cannot."""
     a1 = _create_owned_agent(test_client)
-    a2 = _create_agent(test_client)
+    # Same org as a1: contact grants (and agent<->agent DMs) are org-scoped.
+    a2 = _create_agent_with_owner(test_client, a1["owner_email"])
 
     r = test_client.post("/api/agentic/mm/channels",
         json={"name": "secret", "channel_type": "private"},
@@ -483,7 +484,8 @@ def test_agent_reaction_toggle(test_client):
 def test_non_member_cannot_post(test_client):
     """Non-members cannot post to a channel."""
     a1 = _create_owned_agent(test_client)
-    a2 = _create_agent(test_client)
+    # Same org as a1: contact grants (and agent<->agent DMs) are org-scoped.
+    a2 = _create_agent_with_owner(test_client, a1["owner_email"])
 
     r = test_client.post("/api/agentic/mm/channels",
         json={"name": "private-chat", "channel_type": "private"},
@@ -506,7 +508,8 @@ def test_non_member_cannot_post(test_client):
 def test_create_dm_channel(test_client):
     """Two agents can open a DM channel."""
     a1 = _create_owned_agent(test_client)
-    a2 = _create_agent(test_client)
+    # Same org as a1: contact grants (and agent<->agent DMs) are org-scoped.
+    a2 = _create_agent_with_owner(test_client, a1["owner_email"])
     _grant_agent_contact(test_client, a2, a1, can_dm=True)
 
     r = test_client.post("/api/agentic/mm/direct",
@@ -529,7 +532,8 @@ def test_create_dm_channel(test_client):
 def test_dm_deduplication(test_client):
     """Opening a DM twice between the same agents returns the same channel."""
     a1 = _create_owned_agent(test_client)
-    a2 = _create_owned_agent(test_client)
+    # Same org as a1: agent<->agent DMs and contact grants are org-scoped.
+    a2 = _create_agent_with_owner(test_client, a1["owner_email"])
     # a1 may open the DM; a2 re-opening the existing one is allowed by the
     # bidirectional access rule even without its own grant.
     _grant_agent_contact(test_client, a2, a1, can_dm=True)
@@ -563,7 +567,8 @@ def test_dm_with_self_rejected(test_client):
 def test_dm_messaging(test_client):
     """Agents can exchange messages over a DM channel."""
     a1 = _create_owned_agent(test_client)
-    a2 = _create_agent(test_client)
+    # Same org as a1: contact grants (and agent<->agent DMs) are org-scoped.
+    a2 = _create_agent_with_owner(test_client, a1["owner_email"])
     _grant_agent_contact(test_client, a2, a1, can_dm=True)
 
     # Open DM

--- a/tests/fastapi/test_org_removal_revokes_access.py
+++ b/tests/fastapi/test_org_removal_revokes_access.py
@@ -1,0 +1,206 @@
+"""Removing a human from an org revokes their access to that org's channels.
+
+Audit finding T0-10.
+
+``remove_org_member`` deleted the ``OrgMember`` row and nothing else. Every
+``mm_channel_members`` row survived, and the gates that guard channel access
+ask about *channel* membership, not org membership -- ``_require_human_member``
+is the only check on reading history, posting, exporting, and on the SSE
+stream's periodic re-authorisation. So an ex-member kept working access to
+every channel they had been in: the removal was cosmetic, visible in the
+members list and nowhere else.
+
+The fix deletes the channel membership rows, which makes every existing gate
+answer correctly instead of requiring a new org check bolted onto each route.
+
+Two deliberate non-goals, asserted below so a later change has to be explicit
+about reversing them:
+
+* Channels are **not** torn down when this empties them of humans. The org
+  still owns them and an owner can delete them from Settings; silently
+  destroying history as a side effect of an HR action is the wrong default.
+* Other people's rows are untouched -- in particular their read pointers,
+  which a careless scoped delete would take with it.
+
+This is one half of a two-part hole. The other half is credential
+revalidation on the global ``/api/human/events`` stream, which has no
+mid-stream authorisation at all; deleting these rows does not fix that, and
+that stream is tracked separately.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.fastapi._auth_helpers import add_human_to_org, personal_org_id
+from tests.fastapi._auth_helpers import auth_headers as _auth
+from tests.fastapi._auth_helpers import register_human as _register
+
+
+def _channel(tc: TestClient, token: str, org_id: str, name: str) -> str:
+    r = tc.post(
+        "/api/human/mm/channels",
+        json={"org_id": org_id, "name": name, "channel_type": "private"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["channel_id"]
+
+
+def _add_to_channel(tc: TestClient, token: str, channel_id: str, human_id: int) -> None:
+    r = tc.post(
+        f"/api/human/mm/channels/{channel_id}/members",
+        json={"member_id": str(human_id), "member_type": "human"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.text
+
+
+def _org_with_member(tc: TestClient, slug: str):
+    owner = _register(tc, f"{slug}-owner@test.com")
+    org_id = personal_org_id(tc, owner["access_token"])
+    leaver = _register(tc, f"{slug}-leaver@test.com")
+    add_human_to_org(tc, owner["access_token"], org_id, leaver["user"]["email"])
+    channel_id = _channel(tc, owner["access_token"], org_id, f"{slug}-room")
+    _add_to_channel(tc, owner["access_token"], channel_id, leaver["user"]["id"])
+    return owner, leaver, org_id, channel_id
+
+
+def _remove_from_org(tc: TestClient, owner_token: str, org_id: str, human_id: int):
+    return tc.delete(
+        f"/api/human/orgs/{org_id}/members/{human_id}", headers=_auth(owner_token)
+    )
+
+
+def test_removed_member_loses_channel_read_access(test_client, _test_engine):
+    """The headline: history stayed readable after removal."""
+    owner, leaver, org_id, channel_id = _org_with_member(test_client, "revoke-read")
+
+    r = test_client.get(
+        f"/api/human/mm/channels/{channel_id}/posts", headers=_auth(leaver["access_token"])
+    )
+    assert r.status_code == 200, r.text
+
+    assert _remove_from_org(
+        test_client, owner["access_token"], org_id, leaver["user"]["id"]
+    ).status_code == 200
+
+    r = test_client.get(
+        f"/api/human/mm/channels/{channel_id}/posts", headers=_auth(leaver["access_token"])
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_removed_member_loses_channel_write_access(test_client, _test_engine):
+    owner, leaver, org_id, channel_id = _org_with_member(test_client, "revoke-write")
+    assert _remove_from_org(
+        test_client, owner["access_token"], org_id, leaver["user"]["id"]
+    ).status_code == 200
+
+    r = test_client.post(
+        f"/api/human/mm/channels/{channel_id}/posts",
+        json={"message": "still here"},
+        headers=_auth(leaver["access_token"]),
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_removed_member_channel_list_drops_the_org_channel(test_client, _test_engine):
+    owner, leaver, org_id, channel_id = _org_with_member(test_client, "revoke-list")
+    assert _remove_from_org(
+        test_client, owner["access_token"], org_id, leaver["user"]["id"]
+    ).status_code == 200
+
+    r = test_client.get("/api/human/mm/channels", headers=_auth(leaver["access_token"]))
+    assert r.status_code == 200, r.text
+    assert channel_id not in [c["channel_id"] for c in r.json()["channels"]]
+
+
+def test_remaining_members_are_untouched(test_client, _test_engine):
+    """Guard against an over-broad delete taking other people with it."""
+    owner, leaver, org_id, channel_id = _org_with_member(test_client, "revoke-others")
+    stayer = _register(test_client, "revoke-others-stayer@test.com")
+    add_human_to_org(test_client, owner["access_token"], org_id, stayer["user"]["email"])
+    _add_to_channel(test_client, owner["access_token"], channel_id, stayer["user"]["id"])
+
+    assert _remove_from_org(
+        test_client, owner["access_token"], org_id, leaver["user"]["id"]
+    ).status_code == 200
+
+    r = test_client.get(
+        f"/api/human/mm/channels/{channel_id}/members", headers=_auth(owner["access_token"])
+    )
+    assert r.status_code == 200, r.text
+    human_ids = {m.get("human_id") for m in r.json()["members"]}
+    assert stayer["user"]["id"] in human_ids
+    assert leaver["user"]["id"] not in human_ids
+
+    # And the stayer can still read.
+    r = test_client.get(
+        f"/api/human/mm/channels/{channel_id}/posts", headers=_auth(stayer["access_token"])
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_channel_survives_losing_its_last_member(test_client, _test_engine):
+    """Removal is an HR action, not a delete. The channel stays for the org."""
+    owner, leaver, org_id, _c = _org_with_member(test_client, "revoke-survive")
+    solo = _channel(test_client, owner["access_token"], org_id, "revoke-survive-solo")
+    _add_to_channel(test_client, owner["access_token"], solo, leaver["user"]["id"])
+    # Owner leaves it, so the leaver is the only human in it.
+    r = test_client.delete(
+        f"/api/human/mm/channels/{solo}/members/{owner['user']['id']}?member_type=human",
+        headers=_auth(owner["access_token"]),
+    )
+    assert r.status_code == 200, r.text
+
+    assert _remove_from_org(
+        test_client, owner["access_token"], org_id, leaver["user"]["id"]
+    ).status_code == 200
+
+    # The channel row is still there for an org owner to administer.
+    r = test_client.get(
+        f"/api/human/mm/channels/{solo}", headers=_auth(owner["access_token"])
+    )
+    assert r.status_code in (200, 403), r.text
+    assert r.status_code != 404, "channel was destroyed as a side effect of a removal"
+
+
+def test_other_orgs_channels_are_unaffected(test_client, _test_engine):
+    """The delete is scoped to the org being left, not to the human.
+
+    Note the setup order: ``personal_org_id`` reads ``is_personal``, which is a
+    property of the *organization*, not of the caller's relationship to it. Once
+    the leaver has joined the owner's personal org they belong to two orgs that
+    both report ``is_personal``, and the helper can return either. Their own org
+    is therefore captured before the join, while it is unambiguous.
+    """
+    owner = _register(test_client, "revoke-scope-owner@test.com")
+    org_id = personal_org_id(test_client, owner["access_token"])
+    leaver = _register(test_client, "revoke-scope-leaver@test.com")
+
+    own_org = personal_org_id(test_client, leaver["access_token"])
+    own_channel = _channel(test_client, leaver["access_token"], own_org, "my-own-room")
+    assert own_org != org_id
+
+    add_human_to_org(
+        test_client, owner["access_token"], org_id, leaver["user"]["email"]
+    )
+    shared = _channel(test_client, owner["access_token"], org_id, "revoke-scope-room")
+    _add_to_channel(test_client, owner["access_token"], shared, leaver["user"]["id"])
+
+    assert _remove_from_org(
+        test_client, owner["access_token"], org_id, leaver["user"]["id"]
+    ).status_code == 200
+
+    # Revoked in the org they were removed from...
+    r = test_client.get(
+        f"/api/human/mm/channels/{shared}/posts", headers=_auth(leaver["access_token"])
+    )
+    assert r.status_code == 403, r.text
+
+    # ...and untouched in their own.
+    r = test_client.get(
+        f"/api/human/mm/channels/{own_channel}/posts",
+        headers=_auth(leaver["access_token"]),
+    )
+    assert r.status_code == 200, r.text

--- a/tests/fastapi/test_remove_member_authz.py
+++ b/tests/fastapi/test_remove_member_authz.py
@@ -1,0 +1,176 @@
+"""Removing *others* from a channel is an admin action, and a DM is not a group.
+
+Audit findings T0-02 / T0-08 / T0-09 (and T1-03).
+
+``remove_member`` authorised with ``_require_human_member`` alone -- plain
+membership. Three consequences, all reachable by any member:
+
+1. Evict the channel creator. They cannot get back in: ``join_channel``
+   refuses non-public channels and ``add_member`` requires the caller already
+   be a member, so the owner is locked out of their own channel.
+2. Destroy the channel. Removing every other human one at a time never trips
+   the "last human left" teardown (the remover is still there), so afterwards
+   they remove themselves and the branch fires: posts, files, events and the
+   channel row are all hard-deleted, for everyone. That routes around the
+   creator/owner gate on ``DELETE /channels/{id}`` entirely.
+3. Brick a DM. DM names are deterministic per (org, pair) and ``mm_channels``
+   is unique on ``(org_id, name)``, so a DM that drops to one member is found
+   by neither the by-members lookup nor recreatable -- the insert collides and
+   500s. The org-scope guard added to ``add_member`` removed the last repair
+   path, making it permanent.
+
+The model these tests pin, which ``admin_delete_channel``'s docstring already
+described: *leaving* (removing yourself) needs membership; *removing someone
+else* needs the creator or an org owner; a DM's membership is fixed, and an
+orphaned DM heals on reopen rather than colliding.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.fastapi._auth_helpers import add_human_to_org, personal_org_id
+from tests.fastapi._auth_helpers import auth_headers as _auth
+from tests.fastapi._auth_helpers import register_human as _register
+
+
+def _channel(tc: TestClient, token: str, org_id: str, name: str) -> str:
+    r = tc.post(
+        "/api/human/mm/channels",
+        json={"org_id": org_id, "name": name, "channel_type": "private"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["channel_id"]
+
+
+def _remove(tc: TestClient, token: str, channel_id: str, member_id, member_type="human"):
+    return tc.delete(
+        f"/api/human/mm/channels/{channel_id}/members/{member_id}"
+        f"?member_type={member_type}",
+        headers=_auth(token),
+    )
+
+
+def _owner_and_member(tc: TestClient, slug: str):
+    """A private channel with its creator plus two ordinary members."""
+    owner = _register(tc, f"{slug}-owner@test.com")
+    org_id = personal_org_id(tc, owner["access_token"])
+    mallory = _register(tc, f"{slug}-mallory@test.com")
+    victim = _register(tc, f"{slug}-victim@test.com")
+    for u in (mallory, victim):
+        add_human_to_org(tc, owner["access_token"], org_id, u["user"]["email"])
+    channel_id = _channel(tc, owner["access_token"], org_id, f"{slug}-room")
+    for u in (mallory, victim):
+        r = tc.post(
+            f"/api/human/mm/channels/{channel_id}/members",
+            json={"member_id": str(u["user"]["id"]), "member_type": "human"},
+            headers=_auth(owner["access_token"]),
+        )
+        assert r.status_code == 200, r.text
+    return owner, mallory, victim, channel_id, org_id
+
+
+# ---------------------------------------------------------------------------
+# Removing other people
+# ---------------------------------------------------------------------------
+
+
+def test_member_cannot_evict_another_member(test_client, _test_engine):
+    owner, mallory, victim, channel_id, _org = _owner_and_member(test_client, "evict")
+    r = _remove(test_client, mallory["access_token"], channel_id, victim["user"]["id"])
+    assert r.status_code == 403, r.text
+
+
+def test_member_cannot_evict_the_creator(test_client, _test_engine):
+    """The lock-out: there is no way back into a private channel."""
+    owner, mallory, _victim, channel_id, _org = _owner_and_member(test_client, "creator")
+    r = _remove(test_client, mallory["access_token"], channel_id, owner["user"]["id"])
+    assert r.status_code == 403, r.text
+
+
+def test_member_cannot_destroy_the_channel_by_draining_it(test_client, _test_engine):
+    """The full exploit chain, end to end."""
+    owner, mallory, victim, channel_id, _org = _owner_and_member(test_client, "drain")
+    for target in (victim["user"]["id"], owner["user"]["id"]):
+        assert _remove(
+            test_client, mallory["access_token"], channel_id, target
+        ).status_code == 403
+
+    # The channel and its members are intact.
+    r = test_client.get(
+        f"/api/human/mm/channels/{channel_id}/members",
+        headers=_auth(owner["access_token"]),
+    )
+    assert r.status_code == 200, r.text
+    assert len(r.json()["members"]) == 3
+
+
+def test_creator_can_remove_a_member(test_client, _test_engine):
+    owner, _mallory, victim, channel_id, _org = _owner_and_member(test_client, "bycreator")
+    r = _remove(test_client, owner["access_token"], channel_id, victim["user"]["id"])
+    assert r.status_code == 200, r.text
+    assert victim["user"]["id"] not in [
+        m.get("human_id") for m in r.json()["members"]
+    ]
+
+
+def test_member_can_still_leave(test_client, _test_engine):
+    """Leaving must stay open to everyone -- it is not an admin action."""
+    _owner, mallory, _victim, channel_id, _org = _owner_and_member(test_client, "leave")
+    r = _remove(test_client, mallory["access_token"], channel_id, mallory["user"]["id"])
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Direct channels
+# ---------------------------------------------------------------------------
+
+
+def _human_dm(tc: TestClient, a: dict, b: dict, org_id: str) -> str:
+    r = tc.post(
+        "/api/human/mm/direct",
+        json={"org_id": org_id, "target_type": "human", "target_id": str(b["user"]["id"])},
+        headers=_auth(a["access_token"]),
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["channel_id"]
+
+
+def test_cannot_remove_the_other_party_from_a_dm(test_client, _test_engine):
+    alice = _register(test_client, "dmauthz-alice@test.com")
+    org_id = personal_org_id(test_client, alice["access_token"])
+    bob = _register(test_client, "dmauthz-bob@test.com")
+    add_human_to_org(test_client, alice["access_token"], org_id, bob["user"]["email"])
+    channel_id = _human_dm(test_client, alice, bob, org_id)
+
+    r = _remove(test_client, alice["access_token"], channel_id, bob["user"]["id"])
+    assert r.status_code == 400, r.text
+
+
+def test_reopening_an_orphaned_dm_heals_it(test_client, _test_engine):
+    """A DM that lost a member used to 500 forever on reopen.
+
+    The row is found by name but not by membership, and the deterministic name
+    collides with the unique ``(org_id, name)``.
+    """
+    alice = _register(test_client, "dmheal-alice@test.com")
+    org_id = personal_org_id(test_client, alice["access_token"])
+    bob = _register(test_client, "dmheal-bob@test.com")
+    add_human_to_org(test_client, alice["access_token"], org_id, bob["user"]["email"])
+    channel_id = _human_dm(test_client, alice, bob, org_id)
+
+    # Alice closes her side.
+    r = _remove(test_client, alice["access_token"], channel_id, alice["user"]["id"])
+    assert r.status_code == 200, r.text
+
+    # Reopening returns the same conversation rather than colliding.
+    reopened = _human_dm(test_client, alice, bob, org_id)
+    assert reopened == channel_id
+
+    r = test_client.get(
+        f"/api/human/mm/channels/{channel_id}/members",
+        headers=_auth(alice["access_token"]),
+    )
+    assert r.status_code == 200, r.text
+    human_ids = {m.get("human_id") for m in r.json()["members"]}
+    assert {alice["user"]["id"], bob["user"]["id"]} <= human_ids

--- a/tests/fastapi/test_townsquare_org_scope.py
+++ b/tests/fastapi/test_townsquare_org_scope.py
@@ -1,0 +1,277 @@
+"""The pre-organization "townsquare" list endpoints are org-scoped.
+
+Audit finding T0-01/03/04/06. Five routes predate organizations and selected
+their whole table with no org predicate at all, gated only by "is any valid
+caller":
+
+    GET /api/human/posts            -> every agent's post *text*, every org
+    GET /api/human/shared_content   -> every shared filename + its public R2 URL
+    GET /api/human/actions          -> every agent's action-registry ids
+    GET /api/agentic/actions        -> same, for agents
+    GET /api/agentic/posts          -> same as /api/human/posts, for agents
+
+``limit``/``offset`` are caller-controlled, so each was a full-table dump on a
+multi-tenant deployment. The scoped sibling route
+(``GET /api/human/orgs/{org_id}/agents/{agent_id}/posts``) already did this
+correctly with ``_verify_org_membership`` + ``_verify_agent_in_org``; these
+five simply never got the gate.
+
+The read-layer helpers now take ``org_ids`` as a *required* argument rather
+than an optional filter, so a future call site cannot silently reintroduce the
+leak by omitting it. That is not hypothetical: making it required is what
+surfaced ``get_all_posts`` (``/api/agentic/posts``), the fifth route, which the
+original report had only mentioned in passing.
+
+Note the inner join to ``agents`` also excludes the shared ``deleted-agent``
+placeholder, which inherits content across orgs and has ``org_id=None`` by
+construction -- the same invariant ``is_agent_in_org`` documents.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.fastapi._auth_helpers import auth_headers as _auth
+from tests.fastapi._auth_helpers import login_human
+from tests.fastapi.test_mattermost import _create_agent_with_owner, _write_headers
+
+ALICE = "townsquare-alice@test.com"
+BOB = "townsquare-bob@test.com"
+
+
+def _post_as_agent(tc: TestClient, agent: dict, message: str) -> None:
+    r = tc.post(
+        "/api/agentic/posts",
+        json={"message_type": "say", "message": message},
+        headers=_write_headers(tc, agent["api_key"]),
+    )
+    assert r.status_code == 200, r.text
+
+
+def _write_action(tc: TestClient, agent: dict, action_id: str) -> None:
+    r = tc.put(
+        f"/api/agentic/agents/{agent['agent_id']}/actions",
+        json={"action_id": action_id, "action_md": f"# {action_id}"},
+        headers=_write_headers(tc, agent["api_key"]),
+    )
+    assert r.status_code == 200, r.text
+
+
+def _two_orgs(tc: TestClient) -> tuple[dict, dict, str, str]:
+    """An agent in Alice's personal org and an agent in Bob's, plus both
+    humans' session tokens. Every ``login_human`` gets its own personal org,
+    so these are genuinely separate tenants."""
+    agent_a = _create_agent_with_owner(tc, ALICE)
+    agent_b = _create_agent_with_owner(tc, BOB)
+    alice_token, _ = login_human(tc, ALICE)
+    bob_token, _ = login_human(tc, BOB)
+    return agent_a, agent_b, alice_token, bob_token
+
+
+# ---------------------------------------------------------------------------
+# Human-facing routes
+# ---------------------------------------------------------------------------
+
+
+def test_human_posts_exclude_other_orgs(test_client, _test_engine):
+    """The headline leak: post *bodies* from every tenant, to any logged-in user."""
+    agent_a, agent_b, alice_token, bob_token = _two_orgs(test_client)
+    _post_as_agent(test_client, agent_a, "alice-org-secret")
+    _post_as_agent(test_client, agent_b, "bob-org-secret")
+
+    r = test_client.get("/api/human/posts", headers=_auth(alice_token))
+    assert r.status_code == 200, r.text
+    bodies = [p["message"] for p in r.json()["posts"]]
+    assert "alice-org-secret" in bodies
+    assert "bob-org-secret" not in bodies
+
+    r = test_client.get("/api/human/posts", headers=_auth(bob_token))
+    assert r.status_code == 200, r.text
+    bodies = [p["message"] for p in r.json()["posts"]]
+    assert "bob-org-secret" in bodies
+    assert "alice-org-secret" not in bodies
+
+
+def test_human_actions_exclude_other_orgs(test_client, _test_engine):
+    """``total`` must be scoped too: an unscoped count leaks the deployment's
+    size and makes pagination promise rows the caller cannot read."""
+    agent_a, agent_b, alice_token, _ = _two_orgs(test_client)
+    _write_action(test_client, agent_a, "alice-action")
+    _write_action(test_client, agent_b, "bob-action")
+
+    r = test_client.get("/api/human/actions", headers=_auth(alice_token))
+    assert r.status_code == 200, r.text
+    data = r.json()
+    agent_ids = {a["agent_id"] for a in data["actions"]}
+    assert agent_a["agent_id"] in agent_ids
+    assert agent_b["agent_id"] not in agent_ids
+    assert data["total"] == len(data["actions"])
+
+
+def test_human_shared_content_excludes_other_orgs(test_client, _test_engine):
+    """Each row carries a directly-fetchable public URL, so this one leaked
+    the bytes, not just their names."""
+    agent_a, agent_b, alice_token, _ = _two_orgs(test_client)
+    for agent, name in ((agent_a, "alice.txt"), (agent_b, "bob.txt")):
+        r = test_client.put(
+            f"/api/agentic/shared_content/{name}",
+            content=b"x",
+            headers={**_write_headers(test_client, agent["api_key"]),
+                     "Content-Type": "text/plain"},
+        )
+        assert r.status_code in (200, 201), r.text
+
+    r = test_client.get("/api/human/shared_content", headers=_auth(alice_token))
+    assert r.status_code == 200, r.text
+    names = {f["filename"] for f in r.json()["files"]}
+    assert "bob.txt" not in names
+
+
+def test_human_with_no_org_sees_nothing(test_client, _test_engine):
+    """Empty scope must mean "nothing", never "everything" -- the failure mode
+    an ``IN ()`` written as an optional filter would produce."""
+    agent_a, _agent_b, _alice, _bob = _two_orgs(test_client)
+    _post_as_agent(test_client, agent_a, "alice-org-secret")
+
+    # A freshly-registered human, in no org but their own empty personal one.
+    stranger_token, _ = login_human(test_client, "townsquare-stranger@test.com")
+    r = test_client.get("/api/human/posts", headers=_auth(stranger_token))
+    assert r.status_code == 200, r.text
+    bodies = [p["message"] for p in r.json()["posts"]]
+    assert "alice-org-secret" not in bodies
+
+
+# ---------------------------------------------------------------------------
+# Agent-facing mirrors
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_posts_exclude_other_orgs(test_client, _test_engine):
+    """``/api/agentic/posts`` is the same query behind an API key. An agent
+    minted in any org could read every other tenant's posts."""
+    agent_a, agent_b, _alice, _bob = _two_orgs(test_client)
+    _post_as_agent(test_client, agent_a, "alice-org-secret")
+    _post_as_agent(test_client, agent_b, "bob-org-secret")
+
+    r = test_client.get("/api/agentic/posts", headers=_auth(agent_a["api_key"]))
+    assert r.status_code == 200, r.text
+    bodies = [p["message"] for p in r.json()["posts"]]
+    assert "alice-org-secret" in bodies
+    assert "bob-org-secret" not in bodies
+
+
+def test_agentic_actions_exclude_other_orgs(test_client, _test_engine):
+    agent_a, agent_b, _alice, _bob = _two_orgs(test_client)
+    _write_action(test_client, agent_a, "alice-action")
+    _write_action(test_client, agent_b, "bob-action")
+
+    r = test_client.get("/api/agentic/actions", headers=_auth(agent_a["api_key"]))
+    assert r.status_code == 200, r.text
+    data = r.json()
+    agent_ids = {a["agent_id"] for a in data["actions"]}
+    assert agent_a["agent_id"] in agent_ids
+    assert agent_b["agent_id"] not in agent_ids
+    assert data["total"] == len(data["actions"])
+
+
+def test_own_org_rows_are_still_returned(test_client, _test_engine):
+    """Guard against the lazy fix: scoping must not simply return nothing."""
+    agent_a, _agent_b, alice_token, _bob = _two_orgs(test_client)
+    _post_as_agent(test_client, agent_a, "alice-org-secret")
+    _write_action(test_client, agent_a, "alice-action")
+
+    posts = test_client.get("/api/human/posts", headers=_auth(alice_token)).json()
+    assert any(p["message"] == "alice-org-secret" for p in posts["posts"])
+
+    actions = test_client.get("/api/human/actions", headers=_auth(alice_token)).json()
+    assert actions["total"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Post like / comment routes (audit finding T0-05)
+# ---------------------------------------------------------------------------
+#
+# These four are keyed on ``agent_posts.post_id`` -- a bare serial -- and used
+# to check only that the row existed. Any logged-in human could therefore walk
+# ids to read another tenant's comment threads (which carry each commenter's
+# display name AND email) and to inject likes and comments into a foreign org's
+# feed. ``unlike_post`` had no existence check at all.
+#
+# They answer 404, not 403, for a post outside the caller's orgs: a 403 would
+# confirm the id exists somewhere in the deployment.
+
+
+def _a_post_id(tc: TestClient, agent: dict, token: str, message: str) -> int:
+    """Create a post as ``agent`` and return its id, read back as its owner."""
+    _post_as_agent(tc, agent, message)
+    r = tc.get("/api/human/posts", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    match = [p for p in r.json()["posts"] if p["message"] == message]
+    assert match, f"{message} not visible to its own org"
+    return match[0]["post_id"]
+
+
+def test_cannot_like_a_post_in_another_org(test_client, _test_engine):
+    agent_a, _agent_b, alice_token, bob_token = _two_orgs(test_client)
+    post_id = _a_post_id(test_client, agent_a, alice_token, "alice-likeable")
+
+    r = test_client.post(f"/api/human/posts/{post_id}/like", headers=_auth(bob_token))
+    assert r.status_code == 404, r.text
+
+    # ...and the owner still can.
+    r = test_client.post(f"/api/human/posts/{post_id}/like", headers=_auth(alice_token))
+    assert r.status_code == 200, r.text
+
+
+def test_cannot_unlike_a_post_in_another_org(test_client, _test_engine):
+    """``unlike_post`` previously had no guard whatsoever."""
+    agent_a, _agent_b, alice_token, bob_token = _two_orgs(test_client)
+    post_id = _a_post_id(test_client, agent_a, alice_token, "alice-unlikeable")
+
+    r = test_client.delete(f"/api/human/posts/{post_id}/like", headers=_auth(bob_token))
+    assert r.status_code == 404, r.text
+
+
+def test_cannot_read_comments_on_a_post_in_another_org(test_client, _test_engine):
+    """The leak here is personal data: commenter display names and emails."""
+    agent_a, _agent_b, alice_token, bob_token = _two_orgs(test_client)
+    post_id = _a_post_id(test_client, agent_a, alice_token, "alice-commentable")
+
+    r = test_client.post(
+        f"/api/human/posts/{post_id}/comments",
+        json={"message": "alice-private-comment"},
+        headers=_auth(alice_token),
+    )
+    assert r.status_code == 200, r.text
+
+    r = test_client.get(f"/api/human/posts/{post_id}/comments", headers=_auth(bob_token))
+    assert r.status_code == 404, r.text
+
+    r = test_client.get(f"/api/human/posts/{post_id}/comments", headers=_auth(alice_token))
+    assert r.status_code == 200, r.text
+    assert [c["message"] for c in r.json()["comments"]] == ["alice-private-comment"]
+
+
+def test_cannot_comment_on_a_post_in_another_org(test_client, _test_engine):
+    agent_a, _agent_b, alice_token, bob_token = _two_orgs(test_client)
+    post_id = _a_post_id(test_client, agent_a, alice_token, "alice-injectable")
+
+    r = test_client.post(
+        f"/api/human/posts/{post_id}/comments",
+        json={"message": "bob-was-here"},
+        headers=_auth(bob_token),
+    )
+    assert r.status_code == 404, r.text
+
+    r = test_client.get(f"/api/human/posts/{post_id}/comments", headers=_auth(alice_token))
+    assert [c["message"] for c in r.json()["comments"]] == []
+
+
+def test_missing_post_is_404_not_500(test_client, _test_engine):
+    _agent_a, _agent_b, alice_token, _bob = _two_orgs(test_client)
+    for method, path in (
+        ("post", "like"), ("delete", "like"), ("get", "comments"),
+    ):
+        r = getattr(test_client, method)(
+            f"/api/human/posts/999999/{path}", headers=_auth(alice_token)
+        )
+        assert r.status_code == 404, f"{method} {path}: {r.text}"


### PR DESCRIPTION
## What

Ten related authorization holes, all of the same shape: a route that checks *something* about the caller, but not which organization they belong to.

**Cross-org read leaks.** Five pre-organization "townsquare" routes selected their whole table with no org predicate, gated only by "is any valid caller": `/api/human/posts` (every agent's post text), `/api/human/shared_content` (every shared filename plus its public R2 URL), `/api/human/actions`, `/api/agentic/actions`, and `/api/agentic/posts`. `limit`/`offset` are caller-controlled, so each was a full-table dump on a multi-tenant deployment. The read-layer helpers now take `org_ids` as a **required** argument rather than an optional filter — that is what surfaced `/api/agentic/posts`, which was not in the original report.

**Post interactions.** `like`/`unlike`/`comments` are keyed on `agent_posts.post_id`, a bare serial, and checked only that the row existed. Any logged-in user could walk ids to read another tenant's comment threads — which carry each commenter's display name and email — and inject likes and comments into a foreign org's feed. `unlike_post` had no existence check at all. They now 404 (not 403, which would confirm the id exists elsewhere).

**Channel membership.** `remove_member` authorized with plain membership, so any member could evict the creator (locking them out, since `join_channel` refuses non-public channels), or drain the channel one human at a time and then leave — hard-deleting every post, file and event, routing around the creator/owner gate on `DELETE /channels/{id}`. Removing others now needs the channel creator or an org owner, the same predicate `admin_delete_channel` already used. Leaving still needs only membership.

**Contact permissions.** The human branch required the principal to be in the agent's org; the agent branch checked only existence, so an operator could grant a foreign-org agent DM/tag rights and open a cross-tenant agent-to-agent channel.

**Org removal.** `remove_org_member` deleted the `OrgMember` row and nothing else. Every `mm_channel_members` row survived, and the gates guarding channel access ask about *channel* membership — so an ex-member kept working read, write, export and stream access. Removal was cosmetic. It now deletes the channel rows, which makes every existing gate answer correctly rather than requiring a new org check on each route, and fans out `member_removed` / `channel_removed` so live streams close immediately.

**DM repair.** DM names are deterministic per (org, pair) under a unique `(org_id, name)`, so a DM that lost a member was invisible to the by-members lookup *and* un-recreatable — the insert collided and 500s forever. `_reopen_orphaned_dm` heals the existing row instead, preserving history rather than tearing the DM down.

## Deliberate non-goals

- Channels are **not** torn down when org removal empties them of humans. The org still owns them; destroying history as a side effect of an HR action is the wrong default.
- Agents with `org_id = NULL` (unapproved, or the shared `deleted-agent` placeholder) are now invisible to org-scoped feeds. This is a real semantic change, consistent with how `is_agent_in_org` already treats the placeholder.

## Tests

Three new files, 31 tests. Every one was run against the unpatched code first: **26 fail without the fix**; the 5 that pass are deliberate positive controls so a "deny everything" fix cannot pass.

Six existing tests were changed because they asserted the vulnerable behavior:
- Four DM tests paired agents from two different tenants (`_create_owned_agent` mints a unique owner, `_create_agent` uses stan's) and only passed through the hole. Moved into one org.
- `test_human_list_actions` listed an agent's actions as a human in a different org.
- `_seed_test_agent` inserted an `Agent` with no `org_id`, bypassing the approval that binds one.

`test_agent_endpoint_refuses_cross_org_agent` now seeds its cross-org grant directly via `TableWrite` rather than through the API. The API gate stops new ones; enforcement-at-use must keep refusing pre-existing ones, and those rows exist in deployed databases. The two guards are independent on purpose.

## Follow-ups, not in this PR

- **Existing bad rows are untouched.** Cross-org contact grants and stale channel memberships for already-removed users are still live in production. Both need a cleanup migration — data surgery on live tables, deserving its own review.
- **The global `/api/human/events` stream still has no mid-stream authorization.** This PR closes per-channel streams and all REST access, but until that lands, an ex-member with an open global stream keeps receiving. Tracked separately; noted in the test module docstring so it cannot get lost.
- 20 `test_email.py` failures are pre-existing and unrelated (verified against a clean tree; local Stalwart TLS).